### PR TITLE
V1.1 - adding support to User endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.2
+
+* fixed require path for `Cryptolens::loader()`-function
+
 ## v0.4.1
 
 * added two functions to generate a machine ID for the PHP instance. `Key::getMachineId` returns a hash of the machine ID, whereas `Key::getMachineIdPlain` returns the machine ID in readable format, not hashed. Read the function documentation for information of this hash being calculated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5
+
+* now supporting the Messages endpoints `createMessage`, `removeMessage` and `getMessages`
+* rewritten some error messages
+
 ## v0.4.3
 
 * `$additional_flags` is now parsed correctly to the `Helper::build_params()` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.2
+
+* removed debugging code
+* fixed incorrect array keys for `createTrialKey`-endpoint
+* added support for Key endpoints `createKeyFromTemplate`, `getKey`, `addFeature`, `blockKey` and `extendLicense`
+* added the possibility to change the output format to either JSON or PHP, therefore added the `$output` variable to the `Cryptolens` constructor
+  * when using `Cryptolens::CRYPTOLENS_OUTPUT_PHP` as output, it significantly increases the time to load, where as `Cryptolens::CRYPTOLENS_OUTPUT_JSON` works way faster
+  * certain functions return only a boolean, therefore they are not affected by this setting
+
 ## v0.1
 
 * added Cryptolens classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * added support for Payment Form endpoint `createSession`
 * updated `README.md` with another Code Example and updated the current status of the machine ID generation
 * small changes to the `composer.json`
+* fixed return values for `Key::activate()` to now return arrays on errors to be compliant with the `Helper::outputHelper()` function
 
 ## v0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.7
+
+* added support to Subscription endpoint `record_usage`
+* corrected `group` attribute in `PaymentForm.cryptolens.php`
+
 ## v0.6
 
 * added support to Reseller endpoints `addReseller`, `editReseller`, `removeReseller`, `getResellers` and `getResellerCustomers`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.3
+
+* `$additional_flags` is now parsed correctly to the `Helper::build_params` function
+* booleans are now parsed correctly to the Cryptolens API
+
 ## v0.4.2
 
 * fixed require path for `Cryptolens::loader()`-function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.6
+
+* added support to Reseller endpoints `addReseller`, `editReseller`, `removeReseller`, `getResellers` and `getResellerCustomers`
 
 ## v0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3
+
+* added support for Key endpoints `removeFeature`, `unblockKey`, `machineLockLimit`
+
 ## v0.2
 
 * removed debugging code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.4
+
+* outsourced helper function into the `Helper.cryptolens.php` class
+* improved error messages and removed unnecessary information on failure
+* added the `Auth.cryptolens.php` which brings support to the `keyLock` Auth endpoint
+* added the `Product.cryptolens.php` to support the `getKeys` and `getProducts` endpoint
+
 ## v0.3.1
 
 * added support for composer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.8
+
+* added support to Customer endpoints `addCustomer`, `editCustomer`, `removeCustomer`, `getCustomerLicenses` and `getCustomers`
+
 ## v0.7
 
 * added support to Subscription endpoint `record_usage`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.1
+
+* added support for composer
+* minor change to the `unblock_key`-function, it now returns a true on success and not the full Cryptolens response
+
 ## v0.3
 
 * added support for Key endpoints `removeFeature`, `unblockKey`, `machineLockLimit`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## v0.1
+
+* added Cryptolens classes
+* added support for Key endpoints `activate`, `deactivate`, `createKey` and `createTrialKey`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+* added two functions to generate a machine ID for the PHP instance. `Key::getMachineId` returns a hash of the machine ID, whereas `Key::getMachineIdPlain` returns the machine ID in readable format, not hashed. Read the function documentation for information of this hash being calculated.
+
 ## v0.4
 
 * outsourced helper function into the `Helper.cryptolens.php` class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## v0.4.3
 
-* `$additional_flags` is now parsed correctly to the `Helper::build_params` function
+* `$additional_flags` is now parsed correctly to the `Helper::build_params()` function
 * booleans are now parsed correctly to the Cryptolens API
+* added support for Payment Form endpoint `createSession`
+* updated `README.md` with another Code Example and updated the current status of the machine ID generation
+* small changes to the `composer.json`
 
 ## v0.4.2
 
@@ -11,7 +14,7 @@
 
 ## v0.4.1
 
-* added two functions to generate a machine ID for the PHP instance. `Key::getMachineId` returns a hash of the machine ID, whereas `Key::getMachineIdPlain` returns the machine ID in readable format, not hashed. Read the function documentation for information of this hash being calculated.
+* added two functions to generate a machine ID for the PHP instance. `Key::getMachineId()` returns a hash of the machine ID, whereas `Key::getMachineIdPlain()` returns the machine ID in readable format, not hashed. Read the function documentation for information of this hash being calculated.
 
 ## v0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.1
+
+* added support to User authentication endpoints `login`, `register`, `associate`, `dissociate`, `getUsers`, `changePassword`, `resetPasswordToken`, `removeUser` <!-- I simply forgot this endpoint group exists aswell or it has been added newly. -->
+* added support to Customer endpoint `get_customer_licenses_by_secret`
+
+<!--  additionally removed some unused code and fixed 2 things-->
+
 ## v1.0
 
 * added support to Data endpoints `addDataObject`, `listDataObject`, `incrementIntValue`, `decrementIntValue`, `setStringValue`, `setIntValue`, `removeDataObject`, `uploadValues`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.9
+
+* added error handler class `Errors.cryptolens.php` which will now return you the respectful errors and logs them into files.
+* added support to Analytics endpoints `registerEvent`, `getEvents`, `getObjectLog`, `getWebAPILog`
+* added examples
+
 ## v0.8
 
 * added support to Customer endpoints `addCustomer`, `editCustomer`, `removeCustomer`, `getCustomerLicenses` and `getCustomers`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0
+
+* added support to Data endpoints `addDataObject`, `listDataObject`, `incrementIntValue`, `decrementIntValue`, `setStringValue`, `setIntValue`, `removeDataObject`, `uploadValues`
+* added support for License file validation `License.cryptolens.php`: `verifyLicenseKey`, `verifyLicenseFromFileContent`. See `README.md` for configuration
+
 ## v0.9
 
 * added error handler class `Errors.cryptolens.php` which will now return you the respectful errors and logs them into files.

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -16,6 +16,8 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_PAYMENTFORM = "PaymentForm";
 
         public const CRYPTOLENS_MESSAGE = "Message";
+
+        public const CRYPTOLENS_RESELLER = "Reseller";
         
         private string $token;
 
@@ -64,6 +66,7 @@ namespace Cryptolens_PHP_Client {
             require_once dirname(__FILE__) . "/classes/Product.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/PaymentForm.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Message.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Reseller.cryptolens.php";
 
         }
 

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -6,6 +6,13 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_OUTPUT_PHP = 1;
 
         public const CRYPTOLENS_OUTPUT_JSON = 2;
+
+        public const CRYPTOLENS_KEY = "Key";
+
+        public const CRYPTOLENS_AUTH = "Auth";
+
+        public const CRYPTOLENS_PRODUCT = "Product";
+        
         private string $token;
 
         private int $version = 2;
@@ -45,15 +52,31 @@ namespace Cryptolens_PHP_Client {
         }
 
         public static function loader(){
+            require_once "./classes/Helper.cryptolens.php";
             require_once "./classes/Key.cryptolens.php";
             require_once "./classes/Endpoints.cryptolens.php";
             require_once "./classes/Results.endpoints.cryptolens.php";
+            require_once "./classes/Auth.cryptolens.php";
+            require_once "./classes/Product.cryptolens.php";
         }
 
-        public static function outputHelper($data){
+        public static function outputHelper($data, int $error = 0){
             if(self::$output == self::CRYPTOLENS_OUTPUT_PHP){
+                if($error == 1){
+                    return [
+                        "error" => "An error occured!",
+                        "message" => $data["message"]
+                    ];
+                    
+                }
                 return (array) $data;
             } elseif(self::$output == self::CRYPTOLENS_OUTPUT_JSON){
+                if($error == 1){
+                    return [
+                        "error" => "An error occured!",
+                        "message" => $data["message"]
+                    ];
+                }
                 return json_encode($data);
             }
         }

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -1,11 +1,17 @@
 <?php
 namespace Cryptolens_PHP_Client {
     class Cryptolens {
+
+        public const CRYPTOLENS_OUTPUT_PHP = 1;
+
+        public const CRYPTOLENS_OUTPUT_JSON = 2;
         private string $token;
 
         private int $version = 2;
 
         private int $productId;
+
+        public static int $output;
 
     
         private function set_token(string $token): void{
@@ -15,7 +21,11 @@ namespace Cryptolens_PHP_Client {
             $this->productId = $product_id;
         }
 
-        public function __construct($token, $productid){
+        /**
+         * If $output equals CRYPTOLENS_OUTPUT_PHP you recieve arrays, if it's on CRYPTOLENS_OUTPUT_JSON you recieve json
+         */
+        public function __construct($token, $productid, $output = self::CRYPTOLENS_OUTPUT_PHP){
+            self::$output = $output;
             $this->set_token($token);
             $this->set_product_id($productid);
         }
@@ -28,10 +38,22 @@ namespace Cryptolens_PHP_Client {
             return $this->productId;
         }
 
+        public function set_output($output){
+            $this->output = $output;
+        }
+
         public static function loader(){
             require_once "./classes/Key.cryptolens.php";
             require_once "./classes/Endpoints.cryptolens.php";
             require_once "./classes/Results.endpoints.cryptolens.php";
+        }
+
+        public static function outputHelper($data){
+            if(self::$output == self::CRYPTOLENS_OUTPUT_PHP){
+                return (array) $data;
+            } elseif(self::$output == self::CRYPTOLENS_OUTPUT_JSON){
+                return json_encode($data);
+            }
         }
 
     }

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -1,7 +1,29 @@
 <?php
 
-function cryptolens_activate($token, $product_id, $key, $machine_code)
+class Cryptolens{
+
+
+# ADDED:
+#
+# - function documentation
+# - added type declaration to function parameters (Prevents returning false, if product id is passed as string)
+# - added better error return value handling
+#
+
+/**
+ * cryptolens_activate - Allows you to activate a license key through the Cryptolens API
+ * 
+ * @param string $token The access token from the website <https://app.cryptolens.io/User/AccessToken#/>
+ * @param int $product_id The product id the license is for. You can get this Info by clicking on Products > [Your product] > "Product ID"
+ * @param string $key The license key to activate
+ * @param string $machine_code A unique machine code for the machine the license is being activated for. Length >= 1;
+ * @return boolean|array Returns true on success and an array on failure. Details can be gained with the "error_message" key
+ */
+function cryptolens_activate(string $token, int $product_id, string $key, string $machine_code)
 {
+
+# Check 
+
   $params = 
     array(
         'token' => $token
@@ -41,11 +63,13 @@ function cryptolens_activate($token, $product_id, $key, $machine_code)
     || !property_exists($resp, 'signature')
      )
   {
-    return FALSE;
+    return [
+      "error_message" => "Either message, licenseKey or the signature is missing or empty in the Cryptolens response. Possibly the license key is invalid."
+    ];
   }
 
   $license_key_string = base64_decode($resp->{'licenseKey'});
-  if (!$license_key_string) { return FALSE; }
+  if (!$license_key_string) { return ["error_message" => "Could not decode license key"]; }
 
   $license_key = json_decode($license_key_string);
   if ( is_null($license_key)
@@ -59,21 +83,21 @@ function cryptolens_activate($token, $product_id, $key, $machine_code)
     //|| !is_iterable($license_key->{'ActivatedMachines'})
      )
   {
-    return FALSE;
+    return ["error_message" => "Either the license key is missing or some elements are in the incorrect type in the Cryptolens response"];
   }
 
   if ( $license_key->{'ProductId'} !== $product_id
     || $license_key->{'Key'} !== $key
      )
   {
-    return FALSE;
+    return ["error_message" => "Either the key or the product id might be incorrect."];
   }
 
   $machine_found = FALSE;
   foreach ($license_key->{'ActivatedMachines'} as $machine) {
     if (!property_exists($machine, 'Mid'))
     {
-      return FALSE;
+      return ["error_message" => "The License key has been already activated for this machine"];
     }
 
     if ($machine->{'Mid'} == $machine_code) { $machine_found = TRUE; }
@@ -82,9 +106,10 @@ function cryptolens_activate($token, $product_id, $key, $machine_code)
   if (!$machine_found) { return FALSE; }
 
   $time = time();
-  if ($license_key->{'Expires'} < $time) { return FALSE; }
-
+  if ($license_key->{'Expires'} < $time) { return ["error_message" => "Your key expired! Please get a new one."]; }
   return TRUE;
+}
+
 }
 
 ?>

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -1,112 +1,42 @@
 <?php
+namespace Cryptolens_PHP_Client {
+    class Cryptolens {
+        private string $token;
 
-# ADDED:
-#
-# - function documentation
-# - added type declaration to function parameters (Prevents returning false, if product id is passed as string)
-# - added better error return value handling
-#
+        private int $version = 2;
 
-/**
- * cryptolens_activate - Allows you to activate a license key through the Cryptolens API
- * 
- * @param string $token The access token from the website <https://app.cryptolens.io/User/AccessToken#/>
- * @param int $product_id The product id the license is for. You can get this Info by clicking on Products > [Your product] > "Product ID"
- * @param string $key The license key to activate
- * @param string $machine_code A unique machine code for the machine the license is being activated for. Length >= 1;
- * @return boolean|array Returns true on success and an array on failure. Details can be gained with the "error_message" key
- */
-function cryptolens_activate(string $token, int $product_id, string $key, string $machine_code)
-{
+        private int $productId;
 
-# Check 
+    
+        private function set_token(string $token): void{
+            $this->token = $token;
+        }
+        private function set_product_id($product_id){
+            $this->productId = $product_id;
+        }
 
-  $params = 
-    array(
-        'token' => $token
-      , 'ProductId' => $product_id
-      , 'Key' => $key
-      , 'Sign' => 'True'
-      , 'MachineCode' => $machine_code
-      , 'SignMethod' => 1
-      , 'v' => 1
-      );
-  $postfields = '';
-  $first = TRUE;
-  foreach ($params as $i => $x) {
-    if ($first) { $first = FALSE; } else { $postfields .= '&'; }
+        public function __construct($token, $productid){
+            $this->set_token($token);
+            $this->set_product_id($productid);
+        }
 
-    $postfields .= urlencode($i);
-    $postfields .= '=';
-    $postfields .= urlencode($x);
-  }
-  unset($i, $x);
+        public function get_token(){
+            return $this->token;
+        }
 
-  $curl = curl_init();
-  curl_setopt_array($curl, array(
-      CURLOPT_RETURNTRANSFER => 1
-    , CURLOPT_URL => 'https://app.cryptolens.io/api/key/Activate'
-    , CURLOPT_POST => 1
-    , CURLOPT_POSTFIELDS => $postfields
-  ));
-  $result = curl_exec($curl);
-  curl_close($curl);
+        public function get_product_id(){
+            return $this->productId;
+        }
 
-  $resp = json_decode($result);
-  if ( is_null($resp)
-    || !property_exists($resp, 'message')
-    || $resp->{'message'} !== ''
-    || !property_exists($resp, 'licenseKey')
-    || !property_exists($resp, 'signature')
-     )
-  {
-    return [
-      "error_message" => "Either message, licenseKey or the signature is missing or empty in the Cryptolens response. Possibly the license key is invalid."
-    ];
-  }
+        public static function loader(){
+            require_once "./classes/Key.cryptolens.php";
+            require_once "./classes/Endpoints.cryptolens.php";
+            require_once "./classes/Results.endpoints.cryptolens.php";
+        }
 
-  $license_key_string = base64_decode($resp->{'licenseKey'});
-  if (!$license_key_string) { return ["error_message" => "Could not decode license key"]; }
-
-  $license_key = json_decode($license_key_string);
-  if ( is_null($license_key)
-    || !property_exists($license_key, 'ProductId')
-    || !is_int($license_key->{'ProductId'})
-    || !property_exists($license_key, 'Key')
-    || !is_string($license_key->{'Key'})
-    || !property_exists($license_key, 'Expires')
-    || !is_int($license_key->{'Expires'})
-    || !property_exists($license_key, 'ActivatedMachines')
-    //|| !is_iterable($license_key->{'ActivatedMachines'})
-     )
-  {
-    return ["error_message" => "Either the license key is missing or some elements are in the incorrect type in the Cryptolens response"];
-  }
-
-  if ( $license_key->{'ProductId'} !== $product_id
-    || $license_key->{'Key'} !== $key
-     )
-  {
-    return ["error_message" => "Either the key or the product id might be incorrect."];
-  }
-
-  $machine_found = FALSE;
-  foreach ($license_key->{'ActivatedMachines'} as $machine) {
-    if (!property_exists($machine, 'Mid'))
-    {
-      return ["error_message" => "The License key has been already activated for this machine"];
     }
-
-    if ($machine->{'Mid'} == $machine_code) { $machine_found = TRUE; }
-  }
-  unset($machine);
-  if (!$machine_found) { return FALSE; }
-
-  $time = time();
-  if ($license_key->{'Expires'} < $time) { return ["error_message" => "Your key expired! Please get a new one."]; }
-  return TRUE;
 }
 
-}}
+
 
 ?>

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -52,12 +52,12 @@ namespace Cryptolens_PHP_Client {
         }
 
         public static function loader(){
-            require_once "./classes/Helper.cryptolens.php";
-            require_once "./classes/Key.cryptolens.php";
-            require_once "./classes/Endpoints.cryptolens.php";
-            require_once "./classes/Results.endpoints.cryptolens.php";
-            require_once "./classes/Auth.cryptolens.php";
-            require_once "./classes/Product.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Helper.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Key.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Endpoints.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Results.endpoints.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Auth.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Product.cryptolens.php";
         }
 
         public static function outputHelper($data, int $error = 0){

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -18,6 +18,8 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_MESSAGE = "Message";
 
         public const CRYPTOLENS_RESELLER = "Reseller";
+
+        public const CRYPTOLENS_SUBSCRIPTION = "Subscription";
         
         private string $token;
 
@@ -67,6 +69,7 @@ namespace Cryptolens_PHP_Client {
             require_once dirname(__FILE__) . "/classes/PaymentForm.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Message.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Reseller.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Subscription.cryptolens.php";
 
         }
 

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -20,6 +20,8 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_RESELLER = "Reseller";
 
         public const CRYPTOLENS_SUBSCRIPTION = "Subscription";
+
+        public const CRYPTOLENS_CUSTOMER = "Customer";
         
         private string $token;
 
@@ -70,6 +72,7 @@ namespace Cryptolens_PHP_Client {
             require_once dirname(__FILE__) . "/classes/Message.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Reseller.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Subscription.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Customer.cryptolens.php";
 
         }
 

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -12,6 +12,8 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_AUTH = "Auth";
 
         public const CRYPTOLENS_PRODUCT = "Product";
+
+        public const CRYPTOLENS_PAYMENTFORM = "PaymentForm";
         
         private string $token;
 
@@ -58,6 +60,7 @@ namespace Cryptolens_PHP_Client {
             require_once dirname(__FILE__) . "/classes/Results.endpoints.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Auth.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Product.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/PaymentForm.cryptolens.php";
         }
 
         public static function outputHelper($data, int $error = 0){

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -14,6 +14,8 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_PRODUCT = "Product";
 
         public const CRYPTOLENS_PAYMENTFORM = "PaymentForm";
+
+        public const CRYPTOLENS_MESSAGE = "Message";
         
         private string $token;
 
@@ -61,6 +63,7 @@ namespace Cryptolens_PHP_Client {
             require_once dirname(__FILE__) . "/classes/Auth.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Product.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/PaymentForm.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Message.cryptolens.php";
         }
 
         public static function outputHelper($data, int $error = 0){

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -1,5 +1,11 @@
 <?php
 namespace Cryptolens_PHP_Client {
+    /**
+     * Cryptolens main class
+     * 
+     * This is the cryptolens main class containing an auto loader. It is also holding the sensitive login information needed for the API.
+     * You can define the output to either JSON or Arrays (PHP)
+     */
     class Cryptolens {
 
 
@@ -22,6 +28,10 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_SUBSCRIPTION = "Subscription";
 
         public const CRYPTOLENS_CUSTOMER = "Customer";
+
+        public const CRYPTOLENS_ANALYTICS = "Analytics";
+
+        public const CRYPTOLENS_LICENSE = "License";
         
         private string $token;
 
@@ -63,6 +73,7 @@ namespace Cryptolens_PHP_Client {
 
         public static function loader(){
             require_once dirname(__FILE__) . "/classes/Helper.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Errors.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Key.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Endpoints.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Results.endpoints.cryptolens.php";
@@ -73,6 +84,9 @@ namespace Cryptolens_PHP_Client {
             require_once dirname(__FILE__) . "/classes/Reseller.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Subscription.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Customer.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Analytics.cryptolens.php";
+            @require_once dirname(__FILE__) . "/classes/License.cryptolens.php";
+
 
         }
 

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -32,6 +32,8 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_ANALYTICS = "Analytics";
 
         public const CRYPTOLENS_LICENSE = "License";
+
+        public const CRYPTOLENS_DATA = "Data";
         
         private string $token;
 
@@ -80,6 +82,7 @@ namespace Cryptolens_PHP_Client {
             require_once dirname(__FILE__) . "/classes/Auth.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Product.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/PaymentForm.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/Data.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Message.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Reseller.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Subscription.cryptolens.php";

--- a/Cryptolens.php
+++ b/Cryptolens.php
@@ -34,10 +34,10 @@ namespace Cryptolens_PHP_Client {
         public const CRYPTOLENS_LICENSE = "License";
 
         public const CRYPTOLENS_DATA = "Data";
+
+        public const CRYPTOLENS_USER = "User";
         
         private string $token;
-
-        private int $version = 2;
 
         private int $productId;
 
@@ -88,6 +88,7 @@ namespace Cryptolens_PHP_Client {
             require_once dirname(__FILE__) . "/classes/Subscription.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Customer.cryptolens.php";
             require_once dirname(__FILE__) . "/classes/Analytics.cryptolens.php";
+            require_once dirname(__FILE__) . "/classes/User.cryptolens.php";
             @require_once dirname(__FILE__) . "/classes/License.cryptolens.php";
 
 

--- a/Cryptolens_old.php
+++ b/Cryptolens_old.php
@@ -1,0 +1,90 @@
+<?php
+
+function cryptolens_activate($token, $product_id, $key, $machine_code)
+{
+  $params = 
+    array(
+        'token' => $token
+      , 'ProductId' => $product_id
+      , 'Key' => $key
+      , 'Sign' => 'True'
+      , 'MachineCode' => $machine_code
+      , 'SignMethod' => 1
+      , 'v' => 1
+      );
+  $postfields = '';
+  $first = TRUE;
+  foreach ($params as $i => $x) {
+    if ($first) { $first = FALSE; } else { $postfields .= '&'; }
+
+    $postfields .= urlencode($i);
+    $postfields .= '=';
+    $postfields .= urlencode($x);
+  }
+  unset($i, $x);
+
+  $curl = curl_init();
+  curl_setopt_array($curl, array(
+      CURLOPT_RETURNTRANSFER => 1
+    , CURLOPT_URL => 'https://api.cryptolens.io/api/key/Activate'
+    , CURLOPT_POST => 1
+    , CURLOPT_POSTFIELDS => $postfields
+  ));
+  $result = curl_exec($curl);
+  curl_close($curl);
+
+  $resp = json_decode($result);
+  if ( is_null($resp)
+    || !property_exists($resp, 'message')
+    || $resp->{'message'} !== ''
+    || !property_exists($resp, 'licenseKey')
+    || !property_exists($resp, 'signature')
+     )
+  {
+    return FALSE;
+  }
+
+  $license_key_string = base64_decode($resp->{'licenseKey'});
+  if (!$license_key_string) { return FALSE; }
+
+  $license_key = json_decode($license_key_string);
+  if ( is_null($license_key)
+    || !property_exists($license_key, 'ProductId')
+    || !is_int($license_key->{'ProductId'})
+    || !property_exists($license_key, 'Key')
+    || !is_string($license_key->{'Key'})
+    || !property_exists($license_key, 'Expires')
+    || !is_int($license_key->{'Expires'})
+    || !property_exists($license_key, 'ActivatedMachines')
+    //|| !is_iterable($license_key->{'ActivatedMachines'})
+     )
+  {
+    return FALSE;
+  }
+
+  if ( $license_key->{'ProductId'} !== $product_id
+    || $license_key->{'Key'} !== $key
+     )
+  {
+    return FALSE;
+  }
+
+  $machine_found = FALSE;
+  foreach ($license_key->{'ActivatedMachines'} as $machine) {
+    if (!property_exists($machine, 'Mid'))
+    {
+      return FALSE;
+    }
+
+    if ($machine->{'Mid'} == $machine_code) { $machine_found = TRUE; }
+  }
+  unset($machine);
+  if (!$machine_found) { return FALSE; }
+
+  $time = time();
+  if ($license_key->{'Expires'} < $time) { return FALSE; }
+
+  return TRUE;
+}
+
+?>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Cryptolens AB
+Copyright (c) 2019 Cryptolens AB, Ente
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ to automatically load the required classes.
 * Get Token
 * Analytics
 * Message
+  * [x] get_messages
+  * [x] create_message
+  * [x] remove_message
 * Subscription
 * Reseller
 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,25 @@ In a real values for you can be obtained as follows:
   * [x] deactivate
   * [x] create_key
   * [x] create_trial_key
-  * [ ] create_key_from_template
-  * [ ] get_key
-  * [ ] add_feature
-  * [ ] block_key
-  * [ ] extend_license
+  * [x] create_key_from_template
+  * [x] get_key
+  * [x] add_feature
+  * [x] block_key
+  * [x] extend_license
   * [ ] remove_feature
   * [ ] unblock_key
   * [ ] machine_lock_limit
   * [ ] change_notes
   * [ ] change_reseller
   * [ ] change_customer
+  * [ ] Offline Verification
+* Customer
+* Data Object
+* Product
+* Auth
+* Payment Form
+* Get Token
+* Analytics
+* Message
+* Subscription
+* Reseller

--- a/README.md
+++ b/README.md
@@ -1,38 +1,57 @@
 # Cryptolens PHP
 
 This repository contains functions for interacting with the Cryptolens
-Web API from PHP. Currently only activation of keys is supported.
+Web API from PHP. Currently only a few endpoints are supported and more are following.
+
+To use the library, you can `require_once` the `loader.php` which loads all other classes automatically.
+Inside your script you need to `use` the classes, here is an example:
 
 ## Code example
 
 ```php
 <?php
-require_once('Cryptolens.php');
+ini_set("display_errors", 1);
+require_once "./loader.php";
+use Cryptolens_PHP_Client\Cryptolens;
+use Cryptolens_PHP_Client\Key;
+$c = new Cryptolens("YOUR_TOKEN", 12345);
+$k = new Key($c);
 
-$activate = cryptolens_activate(
-      // Access token
-      'WyI0NjUiLCJBWTBGTlQwZm9WV0FyVnZzMEV1Mm9LOHJmRDZ1SjF0Vk52WTU0VzB2Il0='
-      // Product Id
-    , 3646
-      // License Key
-    , 'MPDWY-PQAOW-FKSCH-SGAAU'
-      // Machine code
-    , '289jf2afs3'
-    );
+$key = "XXXXX-XXXXX-XXXXX-XXXXX";
+$machine_id = "MACHINE-ID";
 
-// $activate is now a boolean indicating if the activation attempt was successful or not
-
+echo "<pre>";
+print_r("Key 'activate':" . var_dump($k->activate($key, $machine_id)));
 ?>
 ```
 
 The code above uses our testing access token, product id, license key and machine code.
 In a real values for you can be obtained as follows:
 
- * Access tokens can be created at https://app.cryptolens.io/User/AccessToken (remember to check 'Activate' and keep everything else unchanged)
- * The product id is found by selecting the relevant product from the list of products
-   (https://app.cryptolens.io/Product), and then the product id is found above the list
+* Access tokens can be created at <https://app.cryptolens.io/User/AccessToken> (remember to check 'Activate' and keep everything else unchanged)
+* The product id is found by selecting the relevant product from the list of products
+   (<https://app.cryptolens.io/Product>), and then the product id is found above the list
    of keys.
- * The license key would be obtained from the user in an application dependant way.
- * Currently the PHP library does not compute the machine code, either the machine
+* The license key would be obtained from the user in an application dependant way.
+* Currently the PHP library does not compute the machine code, either the machine
    code can be computed by the application, or a dummy value can be used. In a future
    release the library itself will compute the machine code.
+
+## Endpoints
+
+* Key
+  * [x] activate
+  * [x] deactivate
+  * [x] create_key
+  * [x] create_trial_key
+  * [ ] create_key_from_template
+  * [ ] get_key
+  * [ ] add_feature
+  * [ ] block_key
+  * [ ] extend_license
+  * [ ] remove_feature
+  * [ ] unblock_key
+  * [ ] machine_lock_limit
+  * [ ] change_notes
+  * [ ] change_reseller
+  * [ ] change_customer

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ In a real values for you can be obtained as follows:
   * [x] add_feature
   * [x] block_key
   * [x] extend_license
-  * [ ] remove_feature
-  * [ ] unblock_key
-  * [ ] machine_lock_limit
-  * [ ] change_notes
-  * [ ] change_reseller
-  * [ ] change_customer
+  * [x] remove_feature
+  * [x] unblock_key
+  * [x] machine_lock_limit
+  * [ ] change_notes*
+  * [ ] change_reseller*
+  * [ ] change_customer*
   * [ ] Offline Verification
 * Customer
 * Data Object
@@ -66,3 +66,5 @@ In a real values for you can be obtained as follows:
 * Message
 * Subscription
 * Reseller
+
+* = Considered with less priority, therefore this endpoint will not be implemented, yet.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ to automatically load the required classes.
   * [x] key_lock **(Use with caution\*\*)**  
 * Payment Form
   * [x] create_session
-* Get Token
 * Analytics
 * Message
   * [x] get_messages
@@ -120,6 +119,11 @@ to automatically load the required classes.
   * [x] remove_message
 * Subscription
 * Reseller
+  * [x] add_reseller
+  * [x] edit_reseller
+  * [x] remove_reseller
+  * [x] get_resellers
+  * [x] get_reseller_customers
 
 * = Considered with less priority, therefore this endpoint will not be implemented, yet.
 * ** = This method creates, retrieves or contains sensitive information (e.g. Access Tokens)

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ require "./vendor/autoload.php";
 ...
 
 ?>
+```
 
 to automatically load the required classes.
 
-```
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ composer require ente/cryptolens-php
 
 ```
 
+And
+
+```php
+<?php
+
+require "./vendor/autoload.php";
+
+...
+
+?>
+
+to automatically load the required classes.
+
+```
+
 ## Endpoints
 
 * Key

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Web API from PHP. Currently only a few endpoints are supported and more are foll
 To use the library, you can `require_once` the `loader.php` which loads all other classes automatically or use composer where you just have to `require` the composer `autoload.php`.
 Inside your script you need to `use` the classes, here is an example:
 
+Needs PHP >7.4.0, works with 8.2
+
 ## Code example
 
 ```php

--- a/README.md
+++ b/README.md
@@ -59,14 +59,17 @@ composer require ente/cryptolens-php
   * [x] remove_feature
   * [x] unblock_key
   * [x] machine_lock_limit
-  * [ ] change_notes*
-  * [ ] change_reseller*
-  * [ ] change_customer*
+  * [ ] change_notes\*
+  * [ ] change_reseller\*
+  * [ ] change_customer\*
   * [ ] Offline Verification
 * Customer
 * Data Object
 * Product
+  * [x] get_keys
+  * [x] get_products
 * Auth
+  * [x] key_lock **(Use with caution\*\*)**  
 * Payment Form
 * Get Token
 * Analytics
@@ -75,3 +78,4 @@ composer require ente/cryptolens-php
 * Reseller
 
 * = Considered with less priority, therefore this endpoint will not be implemented, yet.
+* ** = This method creates, retrieves or contains sensitive information (e.g. Access Tokens)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Cryptolens PHP
 
 This repository contains functions for interacting with the Cryptolens
-Web API from PHP. Currently only a few endpoints are supported and more are following.
+Web API from PHP. Currently most endpoints are supported and more are following.
+
+For more information about the API and possible values and types, visit https://app.cryptolens.io/docs/api/v3, the official API documentation
 
 To use the library, you can `require_once` the `loader.php` which loads all other classes automatically or use composer where you just have to `require` the composer `autoload.php`.
 Inside your script you need to `use` the classes, here is an example:
@@ -104,6 +106,11 @@ to automatically load the required classes.
   * [ ] change_customer\*
   * [ ] Offline Verification
 * Customer
+  * [x] add_customer
+  * [x] edit_customer
+  * [x] remove_customer
+  * [x] get_customer_licenses (does not support the GetCustomerLicensesBySecret Method, yet)
+  * [x] get_customers
 * Data Object
 * Product
   * [x] get_keys

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ to automatically load the required classes.
   * [x] create_message
   * [x] remove_message
 * Subscription
+  * [x] record_usage
 * Reseller
   * [x] add_reseller
   * [x] edit_reseller

--- a/README.md
+++ b/README.md
@@ -3,10 +3,27 @@
 This repository contains functions for interacting with the Cryptolens
 Web API from PHP. Currently only a few endpoints are supported and more are following.
 
-To use the library, you can `require_once` the `loader.php` which loads all other classes automatically.
+To use the library, you can `require_once` the `loader.php` which loads all other classes automatically or use composer where you just have to `require` the composer `autoload.php`.
 Inside your script you need to `use` the classes, here is an example:
 
 ## Code example
+
+```php
+<?php
+ini_set("display_errors", 1);
+require_once "path/to/composer/autoload.php";
+use Cryptolens_PHP_Client\Cryptolens;
+use Cryptolens_PHP_Client\Key;
+$c = new Cryptolens("YOUR_TOKEN", 12345, Cryptolens::CRYPTOLENS_OUTPUT_JSON);
+$k = new Key($c);
+
+$key = "XXXXX-XXXXX-XXXXX-XXXXX";
+$machine_id = $k->getMachineId();
+print_r("Key 'activate':" . var_dump($k->activate($key, $machine_id)));
+?>
+```
+
+## Code Example: Check License for features
 
 ```php
 <?php
@@ -17,9 +34,17 @@ use Cryptolens_PHP_Client\Key;
 $c = new Cryptolens("YOUR_TOKEN", 12345, Cryptolens::CRYPTOLENS_OUTPUT_JSON);
 $k = new Key($c);
 
-$key = "XXXXX-XXXXX-XXXXX-XXXXX";
-$machine_id = "MACHINE-ID";
-print_r("Key 'activate':" . var_dump($k->activate($key, $machine_id)));
+# generate new key and activate Feature 3 for it
+$key = $k->create_key(["F3" => true])["key"];
+
+$license_data = json_decode($k->get_key($key), true);
+
+if($license_data["F3"]){
+  echo "Feature 3 enabled for license " . $key; 
+} elseif($license_data["F4"]){
+  echo "Feature 4 enabled for license " . $key;
+}
+
 ?>
 ```
 
@@ -31,9 +56,7 @@ In a real values for you can be obtained as follows:
    (<https://app.cryptolens.io/Product>), and then the product id is found above the list
    of keys.
 * The license key would be obtained from the user in an application dependant way.
-* Currently the PHP library does not compute the machine code, either the machine
-   code can be computed by the application, or a dummy value can be used. In a future
-   release the library itself will compute the machine code.
+* You can generate a machine ID for the PHP instance with the builtin `Key::getMachineId()` funtion. Please read the function's documentation for more understanding of the calculation of the machine ID.
 
 ## Installation
 
@@ -71,6 +94,7 @@ composer require ente/cryptolens-php
 * Auth
   * [x] key_lock **(Use with caution\*\*)**  
 * Payment Form
+  * [x] create_session
 * Get Token
 * Analytics
 * Message

--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ ini_set("display_errors", 1);
 require_once "./loader.php";
 use Cryptolens_PHP_Client\Cryptolens;
 use Cryptolens_PHP_Client\Key;
-$c = new Cryptolens("YOUR_TOKEN", 12345);
+$c = new Cryptolens("YOUR_TOKEN", 12345, Cryptolens::CRYPTOLENS_OUTPUT_JSON);
 $k = new Key($c);
 
 $key = "XXXXX-XXXXX-XXXXX-XXXXX";
 $machine_id = "MACHINE-ID";
-
-echo "<pre>";
 print_r("Key 'activate':" . var_dump($k->activate($key, $machine_id)));
 ?>
 ```
@@ -28,7 +26,7 @@ print_r("Key 'activate':" . var_dump($k->activate($key, $machine_id)));
 The code above uses our testing access token, product id, license key and machine code.
 In a real values for you can be obtained as follows:
 
-* Access tokens can be created at <https://app.cryptolens.io/User/AccessToken> (remember to check 'Activate' and keep everything else unchanged)
+* Access tokens can be created at <https://app.cryptolens.io/User/AccessToken>
 * The product id is found by selecting the relevant product from the list of products
    (<https://app.cryptolens.io/Product>), and then the product id is found above the list
    of keys.
@@ -36,6 +34,15 @@ In a real values for you can be obtained as follows:
 * Currently the PHP library does not compute the machine code, either the machine
    code can be computed by the application, or a dummy value can be used. In a future
    release the library itself will compute the machine code.
+
+## Installation
+
+You can either clone this repository and require the `loader.php` (which contains a autoloader) or use composer via console:
+
+```bash
+composer require ente/cryptolens-php
+
+```
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,37 @@ In a real values for you can be obtained as follows:
 * You can generate a machine ID for the PHP instance with the builtin `Key::getMachineId()` funtion. Please read the function's documentation for more understanding of the calculation of the machine ID.
 * In an upcoming release this library should be able to also validate license files
 
+### Offline license validation
+
+The API also allows you to validate license files via the `License.cryptolens.php` file.
+To properly configure this function, please convert the XML-styled public key into PEM format (PKC#1) and save it into the `classes/*` directory as `key.pub` (if `License(<Cryptolens $cryptolens>, <string $pathToKey>)` $pathToKey is set, the path is overwritten by specified one).
+
+You can convert your key on a site like this one [here](https://the-x.cn/en-US/certificate/XmlToPem.aspx) or [using this repository](https://github.com/MisterDaneel/PemToXml)
+
+You can then validate a license key like this:
+
+```php
+<?php
+
+require_once "/path/to/autoloader.php";
+use Cryptolens_PHP_Client\Cryptolens;
+use Cryptolens_PHP_Client\License;
+
+$c = new Cryptolens("YOUR_TOKEN", 12345, Cryptolens::CRYPTOLENS_OUTPUT_PHP);
+$l = new License($c); // to specify custom key file location other than /classes/key.pub specify the FULL path as License($c, "/var/www/my/public/key.pub")
+
+$fromString = $l->validateLicense("BASE64-ENCODED-STRING", "BASE64-ENCODED-STRING") // licenseKey and signature
+$fromFileContent = $l->validateLicenseFromFileContent(file_get_contents("license.skm")); // License file as string
+$fromFile = $l->validateLicenseFromFile("license.skm")
+
+if($fromFile){
+  echo "Signature successfully validated";
+} else {
+  echo "Could not verify signature";
+}
+
+```
+
 ## Installation
 
 You can either clone this repository and require the `loader.php` (which contains a autoloader) or use composer via console:
@@ -121,6 +152,11 @@ to automatically load the required classes.
 * Payment Form
   * [x] create_session
 * Analytics
+  * [x] register_event
+  * [x] register_events
+  * [x] get_events
+  * [x] get_object_log
+  * [x] get_web_api_log
 * Message
   * [x] get_messages
   * [x] create_message

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In a real values for you can be obtained as follows:
 ### Offline license validation
 
 The API also allows you to validate license files via the `License.cryptolens.php` file.
-To properly configure this function, please convert the XML-styled public key into PEM format (PKC#1) and save it into the `classes/*` directory as `key.pub` (if `License(<Cryptolens $cryptolens>, <string $pathToKey>)` $pathToKey is set, the path is overwritten by specified one).
+To properly configure this function, please convert the XML-styled public key into PEM format (PKC#1) and save it into the `classes/*` directory as `key.pub` (if `License(<Cryptolens $cryptolens>, <string $pathToKey>)` $pathToKey is set, the path is overwritten by specified one). Currently, only "other languages" formatted license files can be processed by this API client.
 
 You can convert your key on a site like this one [here](https://the-x.cn/en-US/certificate/XmlToPem.aspx) or [using this repository](https://github.com/MisterDaneel/PemToXml)
 
@@ -116,59 +116,3 @@ use Cryptolens_PHP_Client\Cryptolens;
 ```
 
 to automatically load the required classes.
-
-
-## Endpoints
-
-* Key
-  * [x] activate
-  * [x] deactivate
-  * [x] create_key
-  * [x] create_trial_key
-  * [x] create_key_from_template
-  * [x] get_key
-  * [x] add_feature
-  * [x] block_key
-  * [x] extend_license
-  * [x] remove_feature
-  * [x] unblock_key
-  * [x] machine_lock_limit
-  * [ ] change_notes\*
-  * [ ] change_reseller\*
-  * [ ] change_customer\*
-  * [ ] Offline Verification
-* Customer
-  * [x] add_customer
-  * [x] edit_customer
-  * [x] remove_customer
-  * [x] get_customer_licenses (does not support the GetCustomerLicensesBySecret Method, yet)
-  * [x] get_customers
-* Data Object
-* Product
-  * [x] get_keys
-  * [x] get_products
-* Auth
-  * [x] key_lock **(Use with caution\*\*)**  
-* Payment Form
-  * [x] create_session
-* Analytics
-  * [x] register_event
-  * [x] register_events
-  * [x] get_events
-  * [x] get_object_log
-  * [x] get_web_api_log
-* Message
-  * [x] get_messages
-  * [x] create_message
-  * [x] remove_message
-* Subscription
-  * [x] record_usage
-* Reseller
-  * [x] add_reseller
-  * [x] edit_reseller
-  * [x] remove_reseller
-  * [x] get_resellers
-  * [x] get_reseller_customers
-
-* = Considered with less priority, therefore this endpoint will not be implemented, yet.
-* ** = This method creates, retrieves or contains sensitive information (e.g. Access Tokens)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Web API from PHP. Currently most endpoints are supported and more are following.
 
 For more information about the API and possible values and types, visit https://app.cryptolens.io/docs/api/v3, the official API documentation
 
-To use the library, you can `require_once` the `loader.php` which loads all other classes automatically or use composer where you just have to `require` the composer `autoload.php`.
+To use the library, you can `require_once` the `loader.php` which loads all other classes automatically or use composer where you just have to `require` the composer `autoload.php`. Currently, this library is not safe to use for CLI.
 Inside your script you need to `use` the classes, here is an example:
 
 Needs PHP >7.4.0, works with 8.2
@@ -35,7 +35,7 @@ ini_set("display_errors", 1);
 require_once "./loader.php";
 use Cryptolens_PHP_Client\Cryptolens;
 use Cryptolens_PHP_Client\Key;
-$c = new Cryptolens("YOUR_TOKEN", 12345, Cryptolens::CRYPTOLENS_OUTPUT_JSON);
+$c = new Cryptolens("YOUR_TOKEN", 12345, Cryptolens::CRYPTOLENS_OUTPUT_PHP);
 $k = new Key($c);
 
 # generate new key and activate Feature 3 for it
@@ -61,6 +61,7 @@ In a real values for you can be obtained as follows:
    of keys.
 * The license key would be obtained from the user in an application dependant way.
 * You can generate a machine ID for the PHP instance with the builtin `Key::getMachineId()` funtion. Please read the function's documentation for more understanding of the calculation of the machine ID.
+* In an upcoming release this library should be able to also validate license files
 
 ## Installation
 
@@ -77,7 +78,7 @@ And
 <?php
 
 require "./vendor/autoload.php";
-
+use Cryptolens_PHP_Client\Cryptolens;
 ...
 
 ?>

--- a/classes/Analytics.cryptolens.php
+++ b/classes/Analytics.cryptolens.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Cryptolens_PHP_Client {
+    class Analytics extends Cryptolens {
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = Cryptolens::CRYPTOLENS_ANALYTICS;
+        }
+        /**
+         * `register_event()` - Adds a event
+         * 
+         * This function adds a event which has occured in the client application to trigger certain interaction in third-party integrations or else.
+         * According to the API documentation events are hold for 30 days and might get deleted after.
+         * You can provide either the license key or the key ID for the `$key` variable
+         * 
+         * @link https://app.cryptolens.io/docs/api/v3/RegisterEvent
+         *
+         * @param string $key - Either the license key or the key ID, optional
+         * @param string $machineid - Machine ID to parse, optional "but very useful to help us to destinguish the users" (Cryptolens Description for this parameter)
+         * @param string $featurename - The name of the feature, e.g. "VideoRecorder" or "F1", max. 100 chars, optional
+         * @param string $eventname - The name of the event, e.g. "click" or "start". Can be any string of max. 100 chars, optional
+         * @param string $value - The value of the event, decimals allowed, optional
+         * @param string $currency - Currency if the event is an transaction, e.g. "USD"
+         * @param string $metadata - A JSON string with any value. The API states to not parse personal identifiable information unless needed, more information here: https://help.cryptolens.io/legal/DataPolicy
+         * @return bool Returns true on success and false on failure
+         */
+        public function register_event(string $key, string $machineid, string $featurename, string $eventname, string $value, string $currency, string $metadata){
+            $additional_flags = array(
+                "Key" => $key,
+                "MachineCode" => $machineid,
+                "FeatureName" => $featurename,
+                "EventName" => $eventname,
+                "Value" => $value,
+                "Currency" => $currency,
+                "Metadata" => $metadata
+            );
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key, $machineid, $additional_flags);
+            $c = Helper::connection($parms, "registerEvent", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `register_events()` - Adds multiple events
+         * 
+         * This function adds multiple events which has occured in the client application to trigger certain interaction in third-party integrations or else.
+         * According to the API documentation events are hold for 30 days and might get deleted after.
+         * You can provide either the license key or the key ID for the `$key` variable
+         * 
+         * @link https://app.cryptolens.io/docs/api/v3/RegisterEvent
+         *
+         * @param string $key - Either the license key or the key ID, optional
+         * @param string $machineid - Machine ID to parse, optional "but very useful to help us to destinguish the users" (Cryptolens Description for this parameter)
+         * @param array $events an array containing fields FeatureName, EventName, Currency, Time (unix timestamp) and metadata. If no time is specified in any of the objects, the current time will be used instead.
+         * @return bool Returns true on success and false on failure
+         */
+        public function register_events(string $key = null, string $machineid = null, array $events){
+            $additional_flags = array(
+                "Key" => $key,
+                "MachineCode" => $machineid,
+                "Events" => $events
+            );
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key, $machineid, $additional_flags);
+            $c = Helper::connection($parms, "registerEvents", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `get_events()` - Retrieves events registered using the "registerEvent"-API method
+         * 
+         * You may only be returned events no older than 30 days.
+         *
+         * @param integer $limit  	Specifies how many events should be returned.
+         * @param integer|null $startingafter Works as a cursor (for pagination). If the last element had the id=125, then setting this to 125 will return all events coming after 125
+         * @param integer|null $endingbefore Works as a cursor (for pagination). If the last element had the id=125, then setting this to 125 will return all events coming before 125. 
+         * @param array|integer $time Can be either an array or the unix timestamp. Please read more about this in the documentation.
+         * @param integer|null $productid Filter the product
+         * @param $key The key to filter on (Requires set productId)
+         * @param string $metadata Some sort of metadata
+         * @return array|bool Either returns false on failure or the Events within an array which can be accessed via the "Events" key
+         */
+        public function get_events(int $limit = 10, int $startingafter = null, int $endingbefore = null, $time = null, int $product_id = null, string $key = null, $metadata = null){
+            if(isset($key) && !isset($product_id)){
+                return false;
+            }
+            $parms = Helper::build_params($this->cryptolens->get_token(), $product_id ?? $this->cryptolens->get_product_id(), $key, null, array("Limit" => $limit, "StartingAfter" => $startingafter, "EndingBefore" => $endingbefore, "Time" => $time, "Metadata" => $metadata));
+            $c = Helper::connection($parms, "getEvents", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `get_object_log()` - Retrieves a list of object logs 
+         * 
+         * @link https://app.cryptolens.io/docs/api/v3/GetObjectLog
+         *
+         * @param integer $limit Specifies how many events should be returned (default: 10, maximum: 100)
+         * @param integer|null $startingafter For pagination. If the last element had the id=125, then setting this to 125 will return all events coming after 125. 
+         * @return array|bool Either returns an array containing the error message or the object logs (in the "Events" key)
+         */
+        public function get_object_log(int $limit = 10, int $startingafter = null){
+            if($limit > 100){
+                return false;
+            }
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("Limit" => $limit, "StartingAfter" => $startingafter));
+            $c = Helper::connection($parms, "getObjectLog", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `get_web_api_log()` - Retrieves a list of Web API logs 
+         * 
+         * @link https://app.cryptolens.io/docs/api/v3/GetWebAPILog
+         *
+         * @param integer|null $product_id Filter the product id
+         * @param string|null $key Filter for the key
+         * @param integer $limit Specify how many events should be returned (default: 10, maximum: 1000)
+         * @param integer|null $startingafter For pagination.
+         * @param integer|null $endingbefore For pagination.
+         * @param boolean $anomalyClassification If enabled, the result contains informaton about the events returned and any of them could be anomalous
+         * @return array|bool Either returns false or an error array on failure or on success returning an array containing the events, stored in the "Events" key.
+         */
+        public function get_web_api_log(int $product_id = null, string $key = null, $limit = 10, int $startingafter = null, int $endingbefore = null, bool $anomalyClassification = false){
+            if($limit > 1000){
+                return false;
+            }
+
+            if(isset($key) && !isset($product_id)){
+                return false;
+            }
+
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("ProductId" => $product_id, "Key" => $key, "Limit" => $limit, "StartingAfter" => $startingafter, "EndingBefore" => $endingbefore, "AnomalyClassification" => $anomalyClassification));
+            $c = Helper::connection($parms, "getWebAPILog", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}
+
+
+?>

--- a/classes/Auth.cryptolens.php
+++ b/classes/Auth.cryptolens.php
@@ -1,0 +1,38 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class Auth {
+
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+        public function __construct($cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = Cryptolens::CRYPTOLENS_AUTH;
+        }
+
+        /**
+         * key_lock() - Allows you to generate a access token bound to the specified key
+         * 
+         * @param string $key The license key
+         * @return array|bool Returns an array on success, false on failure
+         */
+        public function key_lock($key){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key);
+            $c = Helper::connection($parms, "keyLock", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+
+        }
+    }
+}
+
+
+?>

--- a/classes/Customer.cryptolens.php
+++ b/classes/Customer.cryptolens.php
@@ -1,0 +1,138 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class Customer {
+
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = Cryptolens::CRYPTOLENS_CUSTOMER;
+        }
+
+
+        /**
+         * `add_customer()` - Add a new customer
+         *
+         * @param string $name Name of the customer
+         * @param string $email Emails of the customer
+         * @param string $company_name Company the customer belongs to (max. 100 chars)
+         * @param array $additional_flags Additional flags like "EnableCustomerAssociation" (bool), "AllowActivationManagement" (bool), "AllowMultipleUserAssociation" (bool) 
+         * @return array|false Returns an array containing the customer ID, a secret to alternatively authenticate the customer, result and message. PortalLink is only returned if "EnableCustomerAssociation" is set to true
+         */
+        public function add_customer(string $name, string $email, string $company_name, array $additional_flags = null){
+           if(!isset($additional_flags)){
+                $additional_flags=array();
+            };
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array_merge(array("Name" => $name, "Email" => $email, "CompanyName" => $company_name), $additional_flags));
+            $c = Helper::connection($parms, "addCustomer", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `edit_customer()` - Allows you to edit an customer by their ID
+         *
+         * @param integer $customerId The ID of the customer to edit
+         * @param array $additional_flags Specify the properties you want to edit. Possible keys: "Name", "Email", "CompanyName", "EnableCustomerAssociation" (bool), "AllowMultipleUserAssociation" (bool), "AllowActivationManagement" (bool), "MaxNoOfDevices" (int), "Secret", if true (bool)
+         * @return array|false Returns either "Result" key with value 0 for success or "Error" key on an error
+         */
+        public function edit_customer(int $customerId, array $additional_flags){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array_merge(array("CustomerId" => $customerId), $additional_flags));
+            $c = Helper::connection($parms, "editCustomer", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `remove_customer()` - Allows you to remove an customer by their ID
+         *
+         * @param integer $customerId The ID of the customer to remove
+         * @return array|false Either "Result" with value 0 or false
+         */
+        public function remove_customer(int $customerId){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("CustomerId" => $customerId));
+            $c = Helper::connection($parms, "removeCustomer", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `get_customer_licenses()` - Allows you to retrieve all the customers licenses
+         *
+         * @param integer $customerId The ID of the customer to retrieve the licenses from
+         * @param bool $detailed If set to true, the license will be returned as a License object, default is just returning the serial key (default: false)
+         * @param bool $metadata If set to false, additional information such as number of activated devices will not be returned (default: true)
+         * @return array|false Either "Result" with value 0 or false
+         */
+        public function get_customer_licenses(int $customerId, bool $detailed = false, bool $metadata = true){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("CustomerId" => $customerId, "Detailed" => $detailed, "Metdata" => $metadata));
+            $c = Helper::connection($parms, "getCustomerLicenses", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `get_customers()` - Allows you to retrieve all customers 
+         *
+         * @param string $search If either "Name", "Company", "Email" or "Secret" contains the search string, the result will be returned.
+         * @param int $modelversion Specify if you want a simplified version (1) of the customer objects or more advanced (2). - (default: 1)
+         * @param int $limit Specifiy the number of customers to be returned.
+         * @return array|false Either the customer objects or false
+         */
+        public function get_customers(string $search = null, int $modelversion = 1, int $limit = null){
+            $additional_flags = array();
+            if(isset($search)){
+                $additional_flags["Search"] = $search;
+            }
+            if(isset($limit)){
+                $additional_flags["Limit"] = $limit;
+            }
+            $additional_flags["ModelVersion"] = $modelversion;
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, $additional_flags);
+            $c = Helper::connection($parms, "getCustomers", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}
+
+
+?>

--- a/classes/Customer.cryptolens.php
+++ b/classes/Customer.cryptolens.php
@@ -86,7 +86,7 @@ namespace Cryptolens_PHP_Client {
          * @param integer $customerId The ID of the customer to retrieve the licenses from
          * @param bool $detailed If set to true, the license will be returned as a License object, default is just returning the serial key (default: false)
          * @param bool $metadata If set to false, additional information such as number of activated devices will not be returned (default: true)
-         * @return array|false Either "Result" with value 0 or false
+         * @return array|false Either an array containing the licenses or false
          */
         public function get_customer_licenses(int $customerId, bool $detailed = false, bool $metadata = true){
             $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("CustomerId" => $customerId, "Detailed" => $detailed, "Metdata" => $metadata));

--- a/classes/Customer.cryptolens.php
+++ b/classes/Customer.cryptolens.php
@@ -102,6 +102,28 @@ namespace Cryptolens_PHP_Client {
             }
         }
 
+                /**
+         * `get_customer_licenses_by_secret()` - Allows you to retrieve all the customers licenses
+         *
+         * @param integer $secret The secret of the user to retrieve the licenses from
+         * @param bool $detailed If set to true, the license will be returned as a License object, default is just returning the serial key (default: false)
+         * @param bool $metadata If set to false, additional information such as number of activated devices will not be returned (default: true)
+         * @return array|false Either an array containing the licenses or false
+         */
+        public function get_customer_licenses_by_secret(int $secret, bool $detailed = false, bool $metadata = true){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("Secret" => $secret, "Detailed" => $detailed, "Metdata" => $metadata));
+            $c = Helper::connection($parms, "getCustomerLicensesBySecret", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
         /**
          * `get_customers()` - Allows you to retrieve all customers 
          *

--- a/classes/Data.cryptolens.php
+++ b/classes/Data.cryptolens.php
@@ -1,0 +1,231 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class Data {
+        
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = CRYPTOLENS::CRYPTOLENS_DATA;
+        }
+
+        /**
+         * `addDataObject()` - Adds a new Data Object to either a license key, product or your entire account.
+         * The Cryptolens API provides 3 ways  to add a Data object for each type (license, product or account).
+         * 
+         * @param string $name Name of the DataObject, up to 100 characters
+         * @param string $value A string to store, up to 10k characters
+         * @param string $int optional integer to store, default = 0
+         * @param int $referencerType Where to assign the data object: license key (2), product (1) or User (0), default = 0
+         * @param string $referencerId ID of the referencer, e.g. the license key or product ID. Not required if "User" (0) is referencerType
+         * @param bool $checkForDuplicates If set to true, checking for data objects with the same name
+         * @link https://app.cryptolens.io/docs/api/v3/addDataObject
+         * @return array|bool
+         */
+        public function addDataObject(string $name, string $value, int $int = 0, int $referencerType = 0, string $referencerId = "0", bool $checkForDuplicates = false){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Name" => $name,
+                "StringValue" => $value,
+                "IntValue" => $int,
+                "ReferencerType" => $referencerType,
+                "ReferencerId" => $referencerId,
+                "CheckForDuplicates" => $checkForDuplicates
+            ]);
+
+            $c = Helper::connection($parms, "addDataObject", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `listDataObjects()` - Returns all data objects associated with a key, product or account
+         * @param int $referencerType Where to assign the data object: license key (2), product (1) or User (0), default = 0
+         * @param string $referencerId ID of the referencer, e.g. the license key or product ID. Not required if "User" (0) is referencerType
+         * @param string $contains A string, if set only returns Data object where "name" == $contains, default = ""
+         * @param bool $showAll If set to `true` if returns both license key, product and account specific data objects all at once. Within response it contains the referencerType and Id.
+         * @link https://app.cryptolens.io/docs/api/v3/ListDataObjects
+         * @return array|bool Array on success and false on failure
+         */
+        public function listDataObjects(int $referencerType = 0, string $referencerId = "0", string $contains = "", bool $showAll = true){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "ReferencerType" => $referencerType,
+                "ReferencerId" => $referencerId,
+                "Contains" => $contains,
+                "ShowAll" => $showAll
+            ]);
+            $c = Helper::connection($parms, "listDataObjects", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+        * `incrementIntValue()` - Increment the Int value of an Data Object
+        * @param int $id Unique ID of the data object
+        * @param int $value The value to be incremented on top (if e.g. set to 5 and your existing int is 2 the new one will be 7)
+        * @param bool $enableBound If set to true, you can set a upper bound, e.g. 10 - if you reach 10 an error occurs.
+        * @param int $bond Upper bound to enforce if $enableBond has been enabled
+        * @link https://app.cryptolens.io/docs/api/v3/incrementIntValue
+        * @return array|bool Array on success and false on failure
+        */
+       public function incrementIntValue(int $id, int $value = 0, bool $enableBound = false, int $bound = 0){
+           $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+               "Id" => $id,
+               "IntValue" => $value,
+               "EnableBound" => $enableBound,
+               "Bound" => $bound
+           ]);
+           $c = Helper::connection($parms, "incrementIntValue", $this->group);
+           if($c == true){
+               if(Helper::check_rm($c)){
+                   return Cryptolens::outputHelper($c);
+               } else {
+                   return Cryptolens::outputHelper($c, 1);
+               }
+           } else {
+               return false;
+           }
+       }
+
+        /**
+        * `decrementIntValue()` - Increment the Int value of an Data Object
+        * @param int $id Unique ID of the data object
+        * @param int $value The value to decrement(if e.g. set to 2 and your existing int is 5 the new one will be 3)
+        * @param bool $enableBound If set to true, you can set a lower bound, e.g. 10 - if you reach 10 an error occurs.
+        * @param int $bond Lower bound to enforce if $enableBond has been enabled
+        * @link https://app.cryptolens.io/docs/api/v3/decrementIntValue
+        * @return array|bool Array on success and false on failure
+        */
+        public function decrementIntValue(int $id, int $value = 0, bool $enableBound = false, int $bound = 0){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Id" => $id,
+                "IntValue" => $value,
+                "EnableBound" => $enableBound,
+                "Bound" => $bound
+            ]);
+            $c = Helper::connection($parms, "decrementIntValue", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `setStringValue()` - Set the string value of a data object
+         * @param int $id Unique ID of the data object
+         * @param string $value String value to set
+         * @link https://app.cryptolens.io/docs/api/v3/setStringValue
+         * @return array|bool
+         */
+        public function setStringValue(int $id, string $value = null){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Id" => $id,
+                "StringValue" => $value
+            ]);
+            $c = Helper::connection($parms, "setStringValue", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `setIntValue()` - Set the int value of a data object
+         * @param int $id Unique ID of the data object
+         * @param string $value String value to set
+         * @link https://app.cryptolens.io/docs/api/v3/setIntValue
+         * @return array|bool
+         */
+        public function setIntValue(int $id, int $value = null){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Id" => $id,
+                "IntValue" => $value
+            ]);
+            $c = Helper::connection($parms, "setIntValue", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `removeDataObject()` - Remove a data object
+         * @param int $id Unique ID of the data object
+         * @link https://app.cryptolens.io/docs/api/v3/removeDataObject
+         * @return array|bool
+         */
+        public function removeDataObject(int $id){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Id" => $id
+            ]);
+            $c = Helper::connection($parms, "removeDataObject", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+                /**
+         * `uploadValues()` - Upload values from a Cryptolens log file to either increment or decrement a data object
+         * @param int $id Unique ID of the data object
+         * @param string $key Serial Key
+         * @param string $data String in base64 created by Cryptolens SDK that has recorded data object usage.
+         * @link https://app.cryptolens.io/docs/api/v3/removeDataObject
+         * @return array|bool
+         */
+        public function uploadValues(int $id, string $key, string $data){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key, null, [
+                "Id" => $id,
+                "Data" => $data
+            ]);
+            $c = Helper::connection($parms, "removeDataObject", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}
+
+
+?>

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -5,7 +5,12 @@ namespace Cryptolens_PHP_Client {
             "activate" => "https://api.cryptolens.io/api/key/activate",
             "deactivate" => "https://api.cryptolens.io/api/key/deactivate",
             "createKey" => "https://api.cryptolens.io/api/key/createkey",
-            "createTrialKey" => "https://api.cryptolens.io/api/key/createtrialkey"
+            "createTrialKey" => "https://api.cryptolens.io/api/key/createtrialkey",
+            "createKeyFromTemplate" => "https://api.cryptolens.io/api/key/createkeyfromtemplate",
+            "getKey" => "https://api.cryptolens.io/api/key/getkey",
+            "addFeature" => "https://api.cryptolens.io/api/key/addfeature",
+            "blockKey" => "https://api.cryptolens.io/api/key/blockkey",
+            "extendLicense" => "https://api.cryptolens.io/api/key/extendlicense"
         ];
 
         public static array $no_response_check = [

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -10,7 +10,10 @@ namespace Cryptolens_PHP_Client {
             "getKey" => "https://api.cryptolens.io/api/key/getkey",
             "addFeature" => "https://api.cryptolens.io/api/key/addfeature",
             "blockKey" => "https://api.cryptolens.io/api/key/blockkey",
-            "extendLicense" => "https://api.cryptolens.io/api/key/extendlicense"
+            "extendLicense" => "https://api.cryptolens.io/api/key/extendlicense",
+            "removeFeature" => "https://api.cryptolens.io/api/key/removefeature",
+            "unblockKey" => "https://api.cryptolens.io/api/key/unblockkey",
+            "machineLockLimit" => "https://api.cryptolens.io/api/key/machinelocklimit"
         ];
 
         public static array $no_response_check = [

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -1,0 +1,24 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class Endpoints {
+        public static array $endpoints = [
+            "activate" => "https://api.cryptolens.io/api/key/activate",
+            "deactivate" => "https://api.cryptolens.io/api/key/deactivate",
+            "createKey" => "https://api.cryptolens.io/api/key/createkey",
+            "createTrialKey" => "https://api.cryptolens.io/api/key/createtrialkey"
+        ];
+
+        public static array $no_response_check = [
+            "createKey"
+        ];
+
+        public static function get_endpoint($function_name){
+            if(array_search($function_name, array_flip(self::$endpoints))){
+                return self::$endpoints[$function_name];
+            }
+        }
+    }
+}
+
+
+?>

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -33,7 +33,13 @@ namespace Cryptolens_PHP_Client {
             "getResellers" => "https://api.cryptolens.io/api/reseller/GetResellers",
             "getResellerCustomers" => "https://api.cryptolens.io/api/reseller/GetResellerCustomers",
             # Subscription
-            "recordUsage" => "https://api.cryptolens.io/api/subscription/RecordUsage"
+            "recordUsage" => "https://api.cryptolens.io/api/subscription/RecordUsage",
+            # Customer
+            "addCustomer" => "https://api.cryptolens.io/api/customer/AddCustomer",
+            "editCustomer" => "https://api.cryptolens.io/api/customer/EditCustomer",
+            "removeCustomer" => "https://api.cryptolens.io/api/customer/RemoveCustomer",
+            "getCustomerLicenses" => "https://api.cryptolens.io/api/customer/GetCustomerLicenses",
+            "getCustomers" => "https://api.cryptolens.io/api/customer/GetCustomers"
         ];
 
         public static array $no_response_check = [
@@ -43,6 +49,8 @@ namespace Cryptolens_PHP_Client {
             "getMessages",
             "getResellers",
             "getResellerCustomers",
+            "getCustomerLicenses",
+            "getCustomers"
         ];
 
         public static function get_endpoint($function_name){

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -21,13 +21,18 @@ namespace Cryptolens_PHP_Client {
             "getKeys" => "https://api.cryptolens.io/api/product/getkeys",
             "getProducts" => "https://api.cryptolens.io/api/product/getproducts",
             # PaymentForm
-            "createSession" => "https://api.cryptolens.io/api/paymentform/CreateSession"
+            "createSession" => "https://api.cryptolens.io/api/paymentform/CreateSession",
+            # Message
+            "createMessage" => "https://api.cryptolens.io/api/message/CreateMessage",
+            "removeMessage" => "https://api.cryptolens.io/api/message/RemoveMessage",
+            "getMessages" => "https://api.cryptolens.io/api/message/GetMessages",
         ];
 
         public static array $no_response_check = [
             "createKey",
             "getKeys",
-            "getProducts"
+            "getProducts",
+            "getMessages"
         ];
 
         public static function get_endpoint($function_name){

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -19,7 +19,9 @@ namespace Cryptolens_PHP_Client {
             "keyLock" => "https://api.cryptolens.io/api/auth/keylock",
             # Products
             "getKeys" => "https://api.cryptolens.io/api/product/getkeys",
-            "getProducts" => "https://api.cryptolens.io/api/product/getproducts"
+            "getProducts" => "https://api.cryptolens.io/api/product/getproducts",
+            # PaymentForm
+            "createSession" => "https://api.cryptolens.io/api/paymentform/CreateSession"
         ];
 
         public static array $no_response_check = [

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -2,6 +2,7 @@
 namespace Cryptolens_PHP_Client {
     class Endpoints {
         public static array $endpoints = [
+            # Keys
             "activate" => "https://api.cryptolens.io/api/key/activate",
             "deactivate" => "https://api.cryptolens.io/api/key/deactivate",
             "createKey" => "https://api.cryptolens.io/api/key/createkey",
@@ -13,11 +14,18 @@ namespace Cryptolens_PHP_Client {
             "extendLicense" => "https://api.cryptolens.io/api/key/extendlicense",
             "removeFeature" => "https://api.cryptolens.io/api/key/removefeature",
             "unblockKey" => "https://api.cryptolens.io/api/key/unblockkey",
-            "machineLockLimit" => "https://api.cryptolens.io/api/key/machinelocklimit"
+            "machineLockLimit" => "https://api.cryptolens.io/api/key/machinelocklimit",
+            # Auth
+            "keyLock" => "https://api.cryptolens.io/api/auth/keylock",
+            # Products
+            "getKeys" => "https://api.cryptolens.io/api/product/getkeys",
+            "getProducts" => "https://api.cryptolens.io/api/product/getproducts"
         ];
 
         public static array $no_response_check = [
-            "createKey"
+            "createKey",
+            "getKeys",
+            "getProducts"
         ];
 
         public static function get_endpoint($function_name){

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -32,6 +32,8 @@ namespace Cryptolens_PHP_Client {
             "removeReseller" => "https://api.cryptolens.io/api/reseller/RemoveReseller",
             "getResellers" => "https://api.cryptolens.io/api/reseller/GetResellers",
             "getResellerCustomers" => "https://api.cryptolens.io/api/reseller/GetResellerCustomers",
+            # Subscription
+            "recordUsage" => "https://api.cryptolens.io/api/subscription/RecordUsage"
         ];
 
         public static array $no_response_check = [

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -26,13 +26,21 @@ namespace Cryptolens_PHP_Client {
             "createMessage" => "https://api.cryptolens.io/api/message/CreateMessage",
             "removeMessage" => "https://api.cryptolens.io/api/message/RemoveMessage",
             "getMessages" => "https://api.cryptolens.io/api/message/GetMessages",
+            # Reseller
+            "addReseller" => "https://api.cryptolens.io/api/reseller/AddReseller",
+            "editReseller" => "https://api.cryptolens.io/api/reseller/EditReseller",
+            "removeReseller" => "https://api.cryptolens.io/api/reseller/RemoveReseller",
+            "getResellers" => "https://api.cryptolens.io/api/reseller/GetResellers",
+            "getResellerCustomers" => "https://api.cryptolens.io/api/reseller/GetResellerCustomers",
         ];
 
         public static array $no_response_check = [
             "createKey",
             "getKeys",
             "getProducts",
-            "getMessages"
+            "getMessages",
+            "getResellers",
+            "getResellerCustomers",
         ];
 
         public static function get_endpoint($function_name){

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -45,7 +45,16 @@ namespace Cryptolens_PHP_Client {
             "registerEvents" => "https://api.cryptolens.io/api/ai/RegisterEvents",
             "getEvents" => "https://api.cryptolens.io/api/ai/GetEvents",
             "getObjectLog" => "https://api.cryptolens.io/api/ai/GetObjectLog",
-            "getWebAPILog" => "https://api.cryptolens.io/api/ai/GetWebAPILog"
+            "getWebAPILog" => "https://api.cryptolens.io/api/ai/GetWebAPILog",
+            # Data
+            "addDataObject" => "https://api.cryptolens.io/api/data/AddDataObject",
+            "listDataObjects" => "https://api.cryptolens.io/api/data/ListDataObjects",
+            "incrementIntValue" => "https://api.cryptolens.io/api/data/IncrementIntValue",
+            "decramentIntValue" => "https://api.cryptolens.io/api/data/DecramentIntValue",
+            "setStringValue" => "https://api.cryptolens.io/api/data/SetStringValue",
+            "setIntValue" => "https://api.cryptolens.io/api/data/SetIntValue",
+            "removeDataObject" => "https://api.cryptolens.io/api/data/RemoveDataObject",
+            "uploadValues" => "https://api.cryptolens.io/api/data/UploadValuesToKey"
         ];
 
         public static array $no_response_check = [
@@ -59,7 +68,8 @@ namespace Cryptolens_PHP_Client {
             "getCustomers",
             "getEvents",
             "getWebAPILog",
-            "getObjectsLog"
+            "getObjectsLog",
+            "listDataObjects"
         ];
 
         public static function get_endpoint($function_name){

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -39,6 +39,7 @@ namespace Cryptolens_PHP_Client {
             "editCustomer" => "https://api.cryptolens.io/api/customer/EditCustomer",
             "removeCustomer" => "https://api.cryptolens.io/api/customer/RemoveCustomer",
             "getCustomerLicenses" => "https://api.cryptolens.io/api/customer/GetCustomerLicenses",
+            "getCustomerLicensesBySecret" => "https://api.cryptolens.io/api/customer/GetCustomerLicensesBySecret",
             "getCustomers" => "https://api.cryptolens.io/api/customer/GetCustomers",
             # Analytics
             "registerEvent" => "https://api.cryptolens.io/api/ai/RegisterEvent",
@@ -54,7 +55,16 @@ namespace Cryptolens_PHP_Client {
             "setStringValue" => "https://api.cryptolens.io/api/data/SetStringValue",
             "setIntValue" => "https://api.cryptolens.io/api/data/SetIntValue",
             "removeDataObject" => "https://api.cryptolens.io/api/data/RemoveDataObject",
-            "uploadValues" => "https://api.cryptolens.io/api/data/UploadValuesToKey"
+            "uploadValues" => "https://api.cryptolens.io/api/data/UploadValuesToKey",
+            # User
+            "login" => "https://api.cryptolens.io/api/userauth/Login",
+            "register" => "https://api.cryptolens.io/api/userauth/Register",
+            "associate" => "https://api.cryptolens.io/api/userauth/Associate",
+            "dissociate" => "https://api.cryptolens.io/api/userauth/Dissociate",
+            "getUsers" => "https://api.cryptolens.io/api/userauth/GetUsers",
+            "changePassword" => "https://api.cryptolens.io/api/userauth/ChangePassword",
+            "resetPasswordToken" => "https://api.cryptolens.io/api/userauth/ResetPasswordToken",
+            "removeUser" => "https://api.cryptolens.io/api/userauth/RemoveUser"
         ];
 
         public static array $no_response_check = [
@@ -65,6 +75,8 @@ namespace Cryptolens_PHP_Client {
             "getResellers",
             "getResellerCustomers",
             "getCustomerLicenses",
+            "getCustomerLicensesBySecret",
+            "getUsers",
             "getCustomers",
             "getEvents",
             "getWebAPILog",

--- a/classes/Endpoints.cryptolens.php
+++ b/classes/Endpoints.cryptolens.php
@@ -39,7 +39,13 @@ namespace Cryptolens_PHP_Client {
             "editCustomer" => "https://api.cryptolens.io/api/customer/EditCustomer",
             "removeCustomer" => "https://api.cryptolens.io/api/customer/RemoveCustomer",
             "getCustomerLicenses" => "https://api.cryptolens.io/api/customer/GetCustomerLicenses",
-            "getCustomers" => "https://api.cryptolens.io/api/customer/GetCustomers"
+            "getCustomers" => "https://api.cryptolens.io/api/customer/GetCustomers",
+            # Analytics
+            "registerEvent" => "https://api.cryptolens.io/api/ai/RegisterEvent",
+            "registerEvents" => "https://api.cryptolens.io/api/ai/RegisterEvents",
+            "getEvents" => "https://api.cryptolens.io/api/ai/GetEvents",
+            "getObjectLog" => "https://api.cryptolens.io/api/ai/GetObjectLog",
+            "getWebAPILog" => "https://api.cryptolens.io/api/ai/GetWebAPILog"
         ];
 
         public static array $no_response_check = [
@@ -50,7 +56,10 @@ namespace Cryptolens_PHP_Client {
             "getResellers",
             "getResellerCustomers",
             "getCustomerLicenses",
-            "getCustomers"
+            "getCustomers",
+            "getEvents",
+            "getWebAPILog",
+            "getObjectsLog"
         ];
 
         public static function get_endpoint($function_name){

--- a/classes/Errors.cryptolens.php
+++ b/classes/Errors.cryptolens.php
@@ -1,0 +1,47 @@
+<?php
+namespace Cryptolens_PHP_Client {
+
+    /**
+     * Errors class
+     * 
+     * This class is an implemention of the PHP builtin Exceptions class.
+     * It is able to write to a log and logrotate it - logs are located within the libraries folder (\[document_root\]/data/log...).
+     */
+    class Errors extends \Exception {
+        public function __construct($message, $code = 0, \Exception $previous = null){
+            #$this->error_rep($message);
+            parent::__construct($message, $code, $previous);
+        }
+        public function __toString(){
+            return __CLASS__ . ": [($this->code}]: {$this->message}\n";
+        }
+
+        public static function error_rep($message, $method = NULL){
+            $error_file = self::logrotate(); // file on your fs, e.g. /var/www/html/error.log
+            $version = @json_decode(file_get_contents("../composer.json"), true)["version"];
+            if($method == NULL){
+                $method = $_SERVER["REQUEST_METHOD"];
+            }
+            $time = date("[d.m.Y | H:i:s]");
+            error_log("{$time} \"{$message}\"\nURL: {$_SERVER["HTTP_HOST"]}{$_SERVER["REQUEST_URI"]} \nVersion: {$version} Server IP:{$_SERVER["SERVER_ADDR"]} - Server Name: {$_SERVER["SERVER_NAME"]} - Request Method: '{$method}'\nRemote Addresse: {$_SERVER["REMOTE_ADDR"]} - Remote Name: '{$_SERVER["REMOTE_HOST"]}' - Remote Port: {$_SERVER["REMOTE_PORT"]}\nScript Name: '{$_SERVER["SCRIPT_FILENAME"]}'\n=======================\n", 3, $error_file);
+        }   
+
+        public static function logrotate(){
+            $logpath = $_SERVER["DOCUMENT_ROOT"] . "/data/logs/";
+            $date = date("Y-m-d");
+            $lastrotate = @file_get_contents($_SERVER["DOCUMENT_ROOT"] . "/data/logs/logrotate-cache.txt");
+
+            if($date != $lastrotate){
+                if(!file_exists($logpath . "log-{$date}.log")){
+                    $newlog = $logpath . "log-{$date}.log";
+                    file_put_contents($newlog, "");
+                    file_put_contents($_SERVER["DOCUMENT_ROOT"] . "/data/logs/logrotate-cache.txt", $date);
+                }
+                return $_SERVER["DOCUMENT_ROOT"] . "/data/logs/log-{$date}.log";
+            }
+            return $_SERVER["DOCUMENT_ROOT"] . "/data/logs/log-{$date}.log";
+        }
+    }
+}
+
+?>

--- a/classes/Errors.cryptolens.php
+++ b/classes/Errors.cryptolens.php
@@ -9,10 +9,9 @@ namespace Cryptolens_PHP_Client {
      */
     class Errors extends \Exception {
         public function __construct($message, $code = 0, \Exception $previous = null){
-            #$this->error_rep($message);
             parent::__construct($message, $code, $previous);
         }
-        public function __toString(){
+        public function __toString(): string{
             return __CLASS__ . ": [($this->code}]: {$this->message}\n";
         }
 

--- a/classes/Helper.cryptolens.php
+++ b/classes/Helper.cryptolens.php
@@ -2,7 +2,7 @@
 namespace Cryptolens_PHP_Client {
     class Helper extends Cryptolens {
 
-        public function build_params($token, $product_id, $key = null, $machineid = null, array $additional_flags = null){
+        public static function build_params($token, $product_id, $key = null, $machineid = null, array $additional_flags = null){
             $parms = array(
                 "token" => $token,
                 "ProductId" => $product_id,

--- a/classes/Helper.cryptolens.php
+++ b/classes/Helper.cryptolens.php
@@ -2,7 +2,7 @@
 namespace Cryptolens_PHP_Client {
     class Helper extends Cryptolens {
 
-        public static function build_params($token, $product_id, $key = null, $machineid = null, array $additional_flags = null){
+        public function build_params($token, $product_id, $key = null, $machineid = null, array $additional_flags = null){
             $parms = array(
                 "token" => $token,
                 "ProductId" => $product_id,
@@ -14,13 +14,35 @@ namespace Cryptolens_PHP_Client {
                 $parms["Key"] = $key;
             };
             if($machineid != null){
-                $parms["MachineCode"] = $machineid;
+                $parms["MachineCode"] = "";# empty string to prevent error
             }
             if($additional_flags != null){
-                $parms = array_merge($parms, $additional_flags);
+                if(is_array($additional_flags)){
+                    foreach($additional_flags as $key => $value){
+                        if(is_array($value)){
+                            $value = implode(",", $value);
+                        } elseif(is_bool($value)){
+                            if($value == true){
+                                $value = "true";
+                            } else {
+                                $value = "false";
+                            }
+                        } elseif(!is_string($value)){
+                            $value = (string) $value;
+                        }
+                        $parms[$key] = $value;
+                    }
+                    #print_r(var_dump($parms));
+                } else {
+                    echo "Parsed \$additional_flags not as an array!";
+                }
             }
             $postfields = ''; $first = true;
             foreach($parms as $i => $x){
+                if (is_array($x)) {
+                    // detect array an skip
+                    continue; // Überspringe die Kodierung für diesen Durchlauf
+                }
                 if($first) { $first = false; } else { $postfields .= '&';}
 
                 $postfields .= urlencode($i) . "=" . urlencode($x);

--- a/classes/Helper.cryptolens.php
+++ b/classes/Helper.cryptolens.php
@@ -34,7 +34,7 @@ namespace Cryptolens_PHP_Client {
                     }
                     #print_r(var_dump($parms));
                 } else {
-                    echo "Parsed \$additional_flags not as an array!";
+                    echo "\$additional_flags is not parsed as an array!";
                 }
             }
             $postfields = ''; $first = true;
@@ -77,7 +77,7 @@ namespace Cryptolens_PHP_Client {
 
         private static function check_response($res, $endpoint, $group){
             if(is_null($res)){
-                return "Res == null";
+                return "Cryptolens response returned null. Aborting.";
             } else {
                 if(in_array($endpoint, Endpoints::$no_response_check)){
                     return true;
@@ -85,7 +85,7 @@ namespace Cryptolens_PHP_Client {
                 foreach($res as $r){
                     foreach(Results::get_results()[$group][$endpoint] as $e){
                         if(!strcasecmp($r, $e) == 0){
-                            return "Not found variable";
+                            return "Could not validate response correctly, as some expected keys could not be found in the response.";
                         }
                     }
                 }

--- a/classes/Helper.cryptolens.php
+++ b/classes/Helper.cryptolens.php
@@ -1,0 +1,86 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class Helper extends Cryptolens {
+
+        public static function build_params($token, $product_id, $key = null, $machineid = null, array $additional_flags = null){
+            $parms = array(
+                "token" => $token,
+                "ProductId" => $product_id,
+                "Sign" => "True",
+                "v" => 1,
+                "SignMethod" => 1
+            );
+            if($key != null){
+                $parms["Key"] = $key;
+            };
+            if($machineid != null){
+                $parms["MachineCode"] = $machineid;
+            }
+            if($additional_flags != null){
+                $parms = array_merge($parms, $additional_flags);
+            }
+            $postfields = ''; $first = true;
+            foreach($parms as $i => $x){
+                if($first) { $first = false; } else { $postfields .= '&';}
+
+                $postfields .= urlencode($i) . "=" . urlencode($x);
+
+            }
+            unset($i, $x);
+            return $postfields;
+        }
+
+
+        public static function connection($post, $endpoint, $group){
+            $c = curl_init();
+            curl_setopt_array($c, array(
+                CURLOPT_RETURNTRANSFER => 1,
+                CURLOPT_URL => Endpoints::get_endpoint($endpoint),
+                CURLOPT_POST => 1,
+                CURLOPT_POSTFIELDS => $post
+            ));
+            $res = curl_exec($c);
+            if($res == false){
+                return curl_error($c);
+            }
+            curl_close($c);
+
+            $resp = json_decode($res, true);
+            if(self::check_response($resp, $endpoint, $group) == true){
+                return $resp;
+            } else {
+                return "Could not validate reponse";
+            }
+        }
+
+        private static function check_response($res, $endpoint, $group){
+            if(is_null($res)){
+                return "Res == null";
+            } else {
+                if(in_array($endpoint, Endpoints::$no_response_check)){
+                    return true;
+                }
+                foreach($res as $r){
+                    foreach(Results::get_results()[$group][$endpoint] as $e){
+                        if(!strcasecmp($r, $e) == 0){
+                            return "Not found variable";
+                        }
+                    }
+                }
+                return true;
+            }
+        }
+
+        public static function check_rm($data){
+            if($data["result"] == 0){
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+}
+
+
+
+?>

--- a/classes/Helper.cryptolens.php
+++ b/classes/Helper.cryptolens.php
@@ -32,7 +32,6 @@ namespace Cryptolens_PHP_Client {
                         }
                         $parms[$key] = $value;
                     }
-                    #print_r(var_dump($parms));
                 } else {
                     echo "\$additional_flags is not parsed as an array!";
                 }
@@ -41,7 +40,7 @@ namespace Cryptolens_PHP_Client {
             foreach($parms as $i => $x){
                 if (is_array($x)) {
                     // detect array an skip
-                    continue; // Überspringe die Kodierung für diesen Durchlauf
+                    continue;
                 }
                 if($first) { $first = false; } else { $postfields .= '&';}
 

--- a/classes/Key.cryptolens.php
+++ b/classes/Key.cryptolens.php
@@ -15,7 +15,7 @@ namespace Cryptolens_PHP_Client {
          * @return bool|array Returns an array with the Cryptolens reponse and the decoded license including informations about the key itself. Returns false on failure.
          * @link https://app.cryptolens.io/docs/api/v3/activate
          */
-        public function activate($key, $machineid){
+        public function activate(string $key, string $machineid){
             $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key, $machineid);
             $c = $this->connection($parms, "activate");
             if($c == true){
@@ -62,7 +62,7 @@ namespace Cryptolens_PHP_Client {
          * @param string $machineid The machine ID the key is mapped to, you can leave this empty, but sometimes you recieve an error. Read more in the documentation.
          * @link https://api.cryptolens.io/api/key/deactivate
          */
-        public function deactivate($key, $machineid = null){
+        public function deactivate(string $key, string $machineid = null){
             $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key, $machineid);
             $c = $this->connection($parms, "deactivate");
 
@@ -83,7 +83,7 @@ namespace Cryptolens_PHP_Client {
          * @return array|bool Returns an array with the keys "Key", "CustomerId" (only if "NewCustomer" or "AddOrUseExistingCustomer" is set), "Result" and "Message". The key "Key" gets renamed to "Keys" if "NoOfKeys" is greater than 1. On error it returns the Cryptolens response, with the "error" and "response" key
          * @link https://api.cryptolens.io/api/key/createKey
          */
-        public function create_key($additional_flags = null){
+        public function create_key(array $additional_flags = null){
             $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, $additional_flags);
             $c = $this->connection($parms, "createKey");
             if($c == true){
@@ -105,7 +105,12 @@ namespace Cryptolens_PHP_Client {
             }
         }
 
-        public function create_trial_key($machineId = null){
+        /**
+         * create_trial_key() - Creates a trial key optionally locked to a machineId
+         * 
+         * @param string [optional] Lock the new generated key to a machineId
+         */
+        public function create_trial_key(string $machineId = null){
             $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, $machineId);
             $c = $this->connection($parms, "createTrialKey");
             if($c == true){
@@ -133,7 +138,7 @@ namespace Cryptolens_PHP_Client {
          * @param int $template The template ID, can be obtained from the Products Dashboard > License Templates > Edit and then the number from the URI
          * @return array|bool Returns an array with the response or bool on failure
          */
-        public function create_key_from_template($template){
+        public function create_key_from_template(int $template){
             $parms = $this->build_params($this->cryptolens->get_token(), null, null, null, ["LicenseTemplateId" => $template]);
             $c = $this->connection($parms, "createKeyFromTemplate");
             if($c == true){
@@ -157,7 +162,7 @@ namespace Cryptolens_PHP_Client {
          * @param array $additional_flags Allows you to set more options, like e.g. metadata, fieldstoreturn, floatingtimeinterval and modelversion
          * @return array|bool Returns the key "response" and "licenseKey" (base64 decoded JSON array)
          */
-        public function get_key($key, $additional_flags = null){
+        public function get_key(string $key, array $additional_flags = null){
             $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key, null, $additional_flags);
             $c = $this->connection($parms, "getKey");
             if($c == true){
@@ -251,6 +256,45 @@ namespace Cryptolens_PHP_Client {
                 return false;
             }
         }
+        # returns new key if skgl
+        public function remove_feature(string $key, int $feature){
+            $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key, null, ["Feature" => $feature]);
+            $c = $this->connection($parms, "removeFeature");
+            if($c == true || $this->check_rm($c)){
+                return Cryptolens::outputHelper($c);
+            } else {
+                Cryptolens::outputHelper([
+                    "error" => "An error occured",
+                    "response" => $c
+                ]);
+            }
+        }
+
+        public function unblock_key(string $key){
+            $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key);
+            $c = $this->connection($parms, "unblockKey");
+            if($c == true || $this->check_rm($c)){
+                return Cryptolens::outputHelper($c);
+            } else {
+                Cryptolens::outputHelper([
+                    "error" => "An error occured",
+                    "response" => $c
+                ]);
+            }
+        }
+
+        public function machine_lock_limit(string $key, int $machines){
+            $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key, null, ["NumberOfMachines" => $machines]);
+            $c = $this->connection($parms, "machineLockLimit");
+            if($c == true || $this->check_rm($c)){
+                return Cryptolens::outputHelper($c);
+            } else {
+                Cryptolens::outputHelper([
+                    "error" => "An error occured",
+                    "response" => $c
+                ]);
+            }
+        }
 
         /** 
          * build_params() - Internal helper function building the parameters for the cURL request
@@ -320,6 +364,14 @@ namespace Cryptolens_PHP_Client {
                     }
                 }
                 return true;
+            }
+        }
+
+        private function check_rm($data){
+            if($data["result"] == 0){
+                return true;
+            } else {
+                return false;
             }
         }
     }

--- a/classes/Key.cryptolens.php
+++ b/classes/Key.cryptolens.php
@@ -113,6 +113,7 @@ namespace Cryptolens_PHP_Client {
          */
         public function create_key(array $additional_flags = null){
             $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, $additional_flags);
+            echo $parms;
             $c = $this->connection($parms, "createKey");
             if($c == true){
                 switch($c){
@@ -339,13 +340,35 @@ namespace Cryptolens_PHP_Client {
                 $parms["Key"] = $key;
             };
             if($machineid != null){
-                $parms["MachineCode"] = $machineid;
+                $parms["MachineCode"] = "";# empty string to prevent error
             }
             if($additional_flags != null){
-                $parms = array_merge($parms, $additional_flags);
+                if(is_array($additional_flags)){
+                    foreach($additional_flags as $key => $value){
+                        if(is_array($value)){
+                            $value = implode(",", $value);
+                        } elseif(is_bool($value)){
+                            if($value == true){
+                                $value = "true";
+                            } else {
+                                $value = "false";
+                            }
+                        } elseif(!is_string($value)){
+                            $value = (string) $value;
+                        }
+                        $parms[$key] = $value;
+                    }
+                    #print_r(var_dump($parms));
+                } else {
+                    echo "Parsed \$additional_flags not as an array!";
+                }
             }
             $postfields = ''; $first = true;
             foreach($parms as $i => $x){
+                if (is_array($x)) {
+                    // detect array an skip
+                    continue; // Überspringe die Kodierung für diesen Durchlauf
+                }
                 if($first) { $first = false; } else { $postfields .= '&';}
 
                 $postfields .= urlencode($i) . "=" . urlencode($x);

--- a/classes/Key.cryptolens.php
+++ b/classes/Key.cryptolens.php
@@ -3,9 +3,14 @@ namespace Cryptolens_PHP_Client {
     class Key {
         private Cryptolens $cryptolens;
 
+        /** for future use */
+        private string $group;
+
         public function __construct($cryptolens){
             $this->cryptolens = $cryptolens;
+            $this->group = Cryptolens::CRYPTOLENS_KEY;
         }
+
 
         /**
          * activate() - Activates a Key

--- a/classes/Key.cryptolens.php
+++ b/classes/Key.cryptolens.php
@@ -58,20 +58,32 @@ namespace Cryptolens_PHP_Client {
                 }
 
                 if($license["ProductId"] !== $this->cryptolens->get_product_id() || $license["Key"] !== $key){
-                    return "Malformed response."; # cryptolens response malformed or incorrect on client side
+                    return Cryptolens::outputHelper([
+                        "error" => "An error occured while activating key - Malformed response recieved.",
+                        "response" => $c
+                    ]);
                 }
 
                 $m = false;
                 foreach($license["ActivatedMachines"] as $machine){
                     if(!array_key_exists("Mid", $machine)){
-                        return "Already activated on this client."; # already activated on this client
+                        return Cryptolens::outputHelper([
+                            "error" => "An error occured while activating key - The license has already been enabled on this machine.",
+                            "response" => $c
+                        ]);
                     }
                     if($machine["Mid"] !== $machineid){
-                        return "Devide could not be found."; # device not found
+                        return Cryptolens::outputHelper([
+                            "error" => "An error occured while activating key - The key can not be activated on this machine as the recieved machine ID is not the same as sent.",
+                            "response" => $c
+                        ]);
                     }
                 }
                 if($license["Expires"] < time()){
-                    return "Key already expired."; # key already expired.
+                    return Cryptolens::outputHelper([
+                        "error" => "An error occured while activating key - The key has already expired.",
+                        "response" => $c
+                    ]);
                 }
 
                 return Cryptolens::outputHelper([

--- a/classes/Key.cryptolens.php
+++ b/classes/Key.cryptolens.php
@@ -113,7 +113,6 @@ namespace Cryptolens_PHP_Client {
          */
         public function create_key(array $additional_flags = null){
             $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, $additional_flags);
-            echo $parms;
             $c = $this->connection($parms, "createKey");
             if($c == true){
                 switch($c){

--- a/classes/Key.cryptolens.php
+++ b/classes/Key.cryptolens.php
@@ -1,0 +1,204 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class Key {
+        private Cryptolens $cryptolens;
+
+        public function __construct($cryptolens){
+            $this->cryptolens = $cryptolens;
+        }
+
+        /**
+         * activate() - Activates a Key
+         * 
+         * @param string $key The key to activate
+         * @param string $machineid A unique ID for the machine the key is being activated
+         * @return bool|array Returns an array with the Cryptolens reponse and the decoded license including informations about the key itself. Returns false on failure.
+         * @link https://app.cryptolens.io/docs/api/v3/activate
+         */
+        public function activate($key, $machineid){
+            $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key, $machineid);
+            $c = $this->connection($parms, "activate");
+            if($c == true){
+                $license = json_decode(base64_decode($c["licenseKey"]), true);
+                # check for missing license elements
+                if(is_null($license) ||
+                !array_key_exists("ProductId", $license)||
+                !array_key_exists("Key", $license)||
+                !array_key_exists("Expires", $license)||
+                !array_key_exists("ActivatedMachines", $license)){
+                    return false; # Key, productid, expires or activatedMachines are not set
+                }
+
+                if($license["ProductId"] !== $this->cryptolens->get_product_id() || $license["Key"] !== $key){
+                    return "Malformed response."; # cryptolens response malformed or incorrect on client side
+                }
+
+                $m = false;
+                foreach($license["ActivatedMachines"] as $machine){
+                    if(!array_key_exists("Mid", $machine)){
+                        return "Already activated on this client."; # already activated on this client
+                    }
+                    if($machine["Mid"] !== $machineid){
+                        return "Devide could not be found."; # device not found
+                    }
+                }
+                if($license["Expires"] < time()){
+                    return "Key already expired."; # key already expired.
+                }
+
+                return [
+                    "response" => $c,
+                    "license" => $license
+                ];
+            } else {
+                return $c;
+            }
+        }
+
+        /**
+         * deactivate() - Deactivates the given key
+         * 
+         * @param string $key The key that should be deactivated
+         * @param string $machineid The machine ID the key is mapped to, you can leave this empty, but sometimes you recieve an error. Read more in the documentation.
+         * @link https://api.cryptolens.io/api/key/deactivate
+         */
+        public function deactivate($key, $machineid = null){
+            $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key, $machineid);
+            $c = $this->connection($parms, "deactivate");
+
+            if($c == true){
+                # check response values
+                if($c["result"] == 0){
+                    return true;
+                } else {
+                    return $c;
+                }
+            }
+        }
+
+        /**
+         * create_key() - Creates a key for a specific project
+         * 
+         * @param array $additional_flags Allows to add more than the required parameters e.g. Period, F1-8, Notes, Block, CustomerId, NewCustomer, AddOrUseExistingCustomer, TrialActivations, MaxNoOfMachines, AllowedMachines, ResellerId, NoOfKeys*
+         * @return array|bool Returns an array with the keys "Key", "CustomerId" (only if "NewCustomer" or "AddOrUseExistingCustomer" is set), "Result" and "Message". The key "Key" gets renamed to "Keys" if "NoOfKeys" is greater than 1. On error it returns the Cryptolens response, with the "error" and "response" key
+         * @link https://api.cryptolens.io/api/key/createKey
+         */
+        public function create_key($additional_flags = null){
+            $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, $additional_flags);
+            $c = $this->connection($parms, "createKey");
+            if($c == true){
+                switch($c){
+                    case $c["Result"] != 0:
+                        return [
+                            "error" => "An error occured.",
+                            "response" => $c
+                        ];
+                    case $c["key"] == null && $c["keys"] == null:
+                        return [
+                            "error" => "Key is empty.",
+                            "reponse" => $c
+                        ];
+                };
+                return $c;
+            } else {
+                return false;
+            }
+        }
+
+        public function create_trial_key($machineId = null){
+            $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, $machineId);
+            $c = $this->connection($parms, "createTrialKey");
+            if($c == true){
+                switch($c){
+                    case $c["Result"] != 0:
+                        return [
+                            "error" => "An error occured.",
+                            "response" => $c
+                        ];
+                    case $c["Result"] == 0 && $c["Key"] == null:
+                        return [
+                            "error" => "The key response is empty even though the Result returned 0 (success).",
+                            "response" => $c
+                        ];
+                }
+                return $c;
+            } else {
+                return false;
+            }
+        }
+
+        /** 
+         * build_params() - Internal helper function building the parameters for the cURL request
+         */
+        private function build_params($token, $product_id, $key = null, $machineid = null, array $additional_flags = null){
+            $parms = array(
+                "token" => $token,
+                "ProductId" => $product_id,
+                "Sign" => "True",
+                "v" => 1,
+                "SignMethod" => 1
+            );
+            if($key != null){
+                $parms["Key"] = $key;
+            };
+            if($machineid != null){
+                $parms["MachineCode"] = $machineid;
+            }
+            if($additional_flags != null){
+                $parms = array_merge($parms, $additional_flags);
+            }
+            $postfields = ''; $first = true;
+            foreach($parms as $i => $x){
+                if($first) { $first = false; } else { $postfields .= '&';}
+
+                $postfields .= urlencode($i) . "=" . urlencode($x);
+
+            }
+            unset($i, $x);
+            return $postfields;
+        }
+
+        private function connection($post, $endpoint){
+            $c = curl_init();
+            curl_setopt_array($c, array(
+                CURLOPT_RETURNTRANSFER => 1,
+                CURLOPT_URL => Endpoints::get_endpoint($endpoint),
+                CURLOPT_POST => 1,
+                CURLOPT_POSTFIELDS => $post
+            ));
+            print_r($post);
+            $res = curl_exec($c);
+            if($res == false){
+                return curl_error($c);
+            }
+            curl_close($c);
+
+            $resp = json_decode($res, true);
+            if($this->check_response($resp, $endpoint) == true){
+                return $resp;
+            } else {
+                return "Could not validate reponse";
+            }
+        }
+
+        private function check_response($res, $endpoint){
+            if(is_null($res)){
+                return "Res == null";
+            } else {
+                if(in_array($endpoint, Endpoints::$no_response_check)){
+                    return true;
+                }
+                foreach($res as $r){
+                    foreach(Results::get_results()["Key"][$endpoint] as $e){
+                        if(!strcasecmp($r, $e) == 0){
+                            return "Not found variable";
+                        }
+                    }
+                }
+                return true;
+            }
+        }
+    }
+}
+
+?>

--- a/classes/Key.cryptolens.php
+++ b/classes/Key.cryptolens.php
@@ -11,6 +11,29 @@ namespace Cryptolens_PHP_Client {
             $this->group = Cryptolens::CRYPTOLENS_KEY;
         }
 
+        /**
+         * getMachineId() - Generates a machine ID based on the server's OS, OS version, hostname, architecture, total disk space, unix timestamp of creation of root file system and php's currently installed version
+         * 
+         * The hash generated strips out any white spaces and commas and replaces them with two underlines "__"
+         * The possibility of this method being completely unique is not given, as a update of the php version results in the hash getting invalid.
+         * The function `getMachineIdPlain` allows you to retrieve an JSON to cache this value to generate the hash later on again for comparison.
+         */
+        public static function getMachineId(){
+            $fingerprint = [php_uname(), disk_total_space("."), filectime("/"), phpversion()];
+            return hash("sha256", json_encode($fingerprint));
+        }
+
+        public static function getMachineIdPlain(){
+            $fingerprint = [php_uname(), disk_total_space("."), filectime("/"), phpversion()];
+            foreach($fingerprint as $key => $value){
+                $fingerprint[$key] = str_replace([" ", ",", "\n", "\r", "\t", "\v", "\x00"], "__", $fingerprint[$key]);
+            }
+            $fingerprint = implode("__", $fingerprint);
+            $fingerprint = json_encode($fingerprint);
+
+            return $fingerprint;
+        }
+
 
         /**
          * activate() - Activates a Key

--- a/classes/Key.cryptolens.php
+++ b/classes/Key.cryptolens.php
@@ -202,7 +202,7 @@ namespace Cryptolens_PHP_Client {
             $c = $this->connection($parms, "addFeature");
             if($c == true){
                 if($c["result"] == 0){
-                    return Cryptolens::outputHelper($c);
+                    return true;
                 } else {
                     return Cryptolens::outputHelper([
                         "error" => "An error occured!",
@@ -274,7 +274,7 @@ namespace Cryptolens_PHP_Client {
             $parms = $this->build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), $key);
             $c = $this->connection($parms, "unblockKey");
             if($c == true || $this->check_rm($c)){
-                return Cryptolens::outputHelper($c);
+                return true;
             } else {
                 Cryptolens::outputHelper([
                     "error" => "An error occured",

--- a/classes/License.cryptolens.php
+++ b/classes/License.cryptolens.php
@@ -1,0 +1,65 @@
+<?php
+namespace Cryptolens_PHP_Client {
+
+    class License {
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = Cryptolens::CRYPTOLENS_LICENSE;
+        }
+
+        public function validateLicense(string $licenseKey, string $signature){
+            $licenseKey = base64_decode($licenseKey);
+            $signature = base64_decode($signature);
+
+            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey(), OPENSSL_ALGO_SHA256);
+            if($verified == 1){
+                return true;
+            } else {
+                return false;
+            } 
+        }
+
+        public function validateLicenseFromFileContent(string $fileContent){
+            $fileContent = json_decode($fileContent, true);
+            $licenseKey = base64_decode($fileContent["licenseKey"]);
+            $signature = base64_decode($fileContent["signature"]);
+
+            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey(), OPENSSL_ALGO_SHA256);
+            if($verified == 1){
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        public function validateLicenseFromFile(string $fileContent){
+            $fileContent = json_decode(file_get_contents($fileContent), true);
+            $licenseKey = base64_decode($fileContent["licenseKey"]);
+            $signature = base64_decode($fileContent["signature"]);
+
+            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey(), OPENSSL_ALGO_SHA256);
+            if($verified == 1){
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        public function getPublicKey(string $pathToKey = null){
+            if($pathToKey == null){
+                $pathToKey = dirname(__FILE__, 1) . "/key.pub";
+            }
+            return openssl_pkey_get_public(file_get_contents($pathToKey));
+        }
+
+    }
+}
+
+
+

--- a/classes/License.cryptolens.php
+++ b/classes/License.cryptolens.php
@@ -1,63 +1,114 @@
 <?php
 namespace Cryptolens_PHP_Client {
+    use OpenSSLAsymmetricKey;
 
-    class License {
-        private Cryptolens $cryptolens;
+    class License
+    {
 
         private string $group;
 
+        private string $publicKeyFile;
 
+        private bool $publicKeyIsXMLFormat;
 
-        public function __construct(Cryptolens $cryptolens){
-            $this->cryptolens = $cryptolens;
+        public function __construct(bool $publicKeyIsXMLFormat = false, string $publicKeyFile = null)
+        {
             $this->group = Cryptolens::CRYPTOLENS_LICENSE;
+
+            if ($publicKeyFile != null) {
+                $this->publicKeyFile = $publicKeyFile;
+            } else {
+                $this->publicKeyFile = dirname(__FILE__, 1) . "/key.pub";
+            }
+
+            $this->publicKeyIsXMLFormat = $publicKeyIsXMLFormat;
         }
 
-        public function validateLicense(string $licenseKey, string $signature){
+        /**
+         * `validateLicense()`- Validates a licenseKey against given signature.
+         * @param string $licenseKey The license key
+         * @param string $signature The signature
+         * @return bool True if signature is valid and false otherwise
+         */
+        public function validateLicense(string $licenseKey, string $signature)
+        {
             $licenseKey = base64_decode($licenseKey);
             $signature = base64_decode($signature);
 
-            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey(), OPENSSL_ALGO_SHA256);
-            if($verified == 1){
+            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey($this->publicKeyFile, $this->publicKeyIsXMLFormat), OPENSSL_ALGO_SHA256);
+            if ($verified == 1) {
                 return true;
             } else {
                 return false;
-            } 
+            }
         }
 
-        public function validateLicenseFromFileContent(string $fileContent){
+        /**
+         * `validateLicenseFromFileContent` - Validates the licenseKey against signature from given license file content
+         * @param string $fileContent The file content as string
+         * @return bool True if signature is valid and false otherwise
+         */
+        public function validateLicenseFromFileContent(string $fileContent)
+        {
             $fileContent = json_decode($fileContent, true);
             $licenseKey = base64_decode($fileContent["licenseKey"]);
             $signature = base64_decode($fileContent["signature"]);
 
-            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey(), OPENSSL_ALGO_SHA256);
-            if($verified == 1){
+            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey($this->publicKeyFile, $this->publicKeyIsXMLFormat), OPENSSL_ALGO_SHA256);
+            if ($verified == 1) {
                 return true;
             } else {
                 return false;
             }
         }
 
-        public function validateLicenseFromFile(string $fileContent){
-            $fileContent = json_decode(file_get_contents($fileContent), true);
+        /**
+         * `validateLicenseFromFile()` - Validates the licenseKey against a signature from given license key file path
+         * @param string $fileContent The file path of the license
+         * @return bool True if signature is valid and false otherwise
+         */
+        public function validateLicenseFromFile(string $fileContent)
+        {
+            $fileContent = $this->readLicenseFile($fileContent);
             $licenseKey = base64_decode($fileContent["licenseKey"]);
             $signature = base64_decode($fileContent["signature"]);
 
-            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey(), OPENSSL_ALGO_SHA256);
-            if($verified == 1){
+            $verified = openssl_verify($licenseKey, $signature, $this->getPublicKey($this->publicKeyFile, $this->publicKeyIsXMLFormat), OPENSSL_ALGO_SHA256);
+            if ($verified == 1) {
                 return true;
             } else {
                 return false;
             }
         }
 
-        public function getPublicKey(string $pathToKey = null){
-            if($pathToKey == null){
+        /**
+         * `getPublicKey()` - Reads the public key from your specified file or from default ./classes/key.pub
+         * @param string $pathToKey
+         * @return bool|\OpenSSLAsymmetricKey
+         */
+        public function getPublicKey(string $pathToKey = null, bool $xml = false)
+        {
+            if ($pathToKey == null) {
                 $pathToKey = dirname(__FILE__, 1) . "/key.pub";
             }
-            return openssl_pkey_get_public(file_get_contents($pathToKey));
+
+
+            if ($xml == true) {
+                return openssl_pkey_get_public(file_get_contents($pathToKey));
+            } else {
+                return openssl_pkey_get_public(file_get_contents($pathToKey));
+            }
         }
 
+        /**
+         * 
+         * @param string $filePath
+         * @return mixed
+         */
+        public function readLicenseFile(string $filePath)
+        {
+            return json_decode(file_get_contents($filePath), true);
+        }
     }
 }
 

--- a/classes/Message.cryptolens.php
+++ b/classes/Message.cryptolens.php
@@ -1,0 +1,113 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    /**
+     * Messages - Allows you to broadcast messages.
+     * You can create messages via GUI here: https://app.cryptolens.io/Message
+     * @link https://help.cryptolens.io/messaging/index
+     * @link https://app.cryptolens.io/docs/api/v3/Message
+     */
+    class Message {
+
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+        private string $channel;
+
+        /**
+         * __construct
+         *
+         * @param Cryptolens $cryptolens
+         * @param string|null $channel Additonal parameter to overwrite 
+         */
+        public function __construct(Cryptolens $cryptolens, string $channel = null){
+            $this->cryptolens = $cryptolens;
+            $this->group = Cryptolens::CRYPTOLENS_MESSAGE;
+            if($channel == null){
+                $this->channel = "";
+            } else {
+                $this->channel = $channel;
+            }
+        }
+
+        /**
+         * `create_message()` - Allows you to create a new message to broadcast
+         * 
+         * @param string $content The content of your message (This is optional for the API but what's the point of it, if you don't specify a message.) A link or something similar can be set aswell.
+         * @param array|null $additional_flags This allows you to set additional flags, such as the Channel (string, can be overwritten via constructor) or Time (unix timestamp)
+         * @return array|false Returns the response array with the message ID or false on error.
+         * @link https://api.cryptolens.io/api/message/CreateMessage
+         */
+
+        public function create_message(string $content, array $additional_flags = null){
+            if($this->channel != ""){
+                $additional_flags["Channel"] = $this->channel;
+            }
+            if($additional_flags == null){$additional_flags = array();};
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array_merge(array("Content" => $content), $additional_flags));
+            $c = Helper::connection($parms, "createMessage", "Message");
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `remove_message()` - Removes a message with id.
+         *
+         * @param integer $message_id The Id from the message to be removed.
+         * @return array|false Returns either an array, containing the "Result" key which either is 0 for success or 1 if an error occured. Returning false on connection error. 
+         */
+        public function remove_message(int $message_id){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("Id" => $message_id));
+            $c = Helper::connection($parms, "removeMessage", "Message");
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `get_messages()` - Allows you to retrieve messages for a specific channel or time
+         *
+         *  This function retrieves messages for a specific `$channel` (or all, if left empty) which are older than `$greather_than` timestamp.
+         *  If you leave `$channel` and `$greater_than` empty, it will return you all messages
+         * 
+         * @param string|null $channel The channel you want to retrieve messages for (may be overwritten if you set the channel variable in the constructor).
+         * @param integer|null $greater_than Retrieve messages created after `$greather_than` (unix timestamp, strictly 'greather than'). Might be useful to retrieve messages from last time you used this function.
+         * @return array|false Returns an array with all messages or false on error
+         */
+        public function get_messages(string $channel = null, int $greater_than = null){
+            if(isset($channel)){
+                $additional_flags["Channel"] = $channel;
+            }
+            if(isset($greater_than)){
+                $additional_flags["Time"] = $greater_than;
+            }
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, $additional_flags);
+            $c = Helper::connection($parms, "getMessages", "Message");
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}
+
+
+?>

--- a/classes/PaymentForm.cryptolens.php
+++ b/classes/PaymentForm.cryptolens.php
@@ -27,7 +27,7 @@ namespace Cryptolens_PHP_Client {
          * @link https://api.cryptolens.io/api/paymentform/CreateSession
          */
 
-        public function create_session($form_id, $expires = 60, $price = 0, $currency = "USD", $additional_flags = null){
+        public function create_session(int $form_id, int $expires = 60, float $price = 0, string $currency = "USD", array $additional_flags = null){
             if($additional_flags == null){$additional_flags = array();};
             $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array_merge(array("PaymentFormId" => $form_id, "Expires" => $expires, "Prices" => $price, "Currency" => $currency), $additional_flags));
             $c = Helper::connection($parms, "createSession", "PaymentForm");

--- a/classes/PaymentForm.cryptolens.php
+++ b/classes/PaymentForm.cryptolens.php
@@ -1,0 +1,48 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class PaymentForm {
+
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = Cryptolens::CRYPTOLENS_PRODUCT;
+        }
+
+        /**
+         * `create_session()` - Allows you to create a new session for a payment form. You can change the appearance of the form (such as price, heading, etc.)
+         * 
+         * Sessions should only be generated server-side e.g. from your application. A session only works once and may expire if the if it exceeds "Expire" parameter.
+         * This API endpoint does return the "Message" key without providing a message on success.
+         * 
+         * @param int $form_id The ID of the payment form. (Obtained by opening your Payment Form and copying the number at the end of the URL)
+         * @param int $expires Number of seconds the session should be valid. (Default: 60)
+         * @param float $price The amount to charge the customer (Default: 0)
+         * @param string $currency ISO currency code (alphabetical) (Default: USD) - See here for a list: https://en.wikipedia.org/wiki/ISO_4217#Active_codes_(List_One)
+         * @param array $additional_flags Set optional parameters such as "Heading", "ProductName", "CustomField" or "Metadata"
+         * @return int|array Returns either the UID for the session associated with the customer or an array with "error" and "message" keys
+         * @link https://api.cryptolens.io/api/paymentform/CreateSession
+         */
+
+        public function create_session($form_id, $expires = 60, $price = 0, $currency = "USD", $additional_flags = null){
+            if($additional_flags == null){$additional_flags = array();};
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array_merge(array("PaymentFormId" => $form_id, "Expires" => $expires, "Prices" => $price, "Currency" => $currency), $additional_flags));
+            $c = Helper::connection($parms, "createSession", "PaymentForm");
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}
+
+
+?>

--- a/classes/PaymentForm.cryptolens.php
+++ b/classes/PaymentForm.cryptolens.php
@@ -9,7 +9,7 @@ namespace Cryptolens_PHP_Client {
 
         public function __construct(Cryptolens $cryptolens){
             $this->cryptolens = $cryptolens;
-            $this->group = Cryptolens::CRYPTOLENS_PRODUCT;
+            $this->group = Cryptolens::CRYPTOLENS_PAYMENTFORM;
         }
 
         /**
@@ -30,7 +30,7 @@ namespace Cryptolens_PHP_Client {
         public function create_session(int $form_id, int $expires = 60, float $price = 0, string $currency = "USD", array $additional_flags = null){
             if($additional_flags == null){$additional_flags = array();};
             $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array_merge(array("PaymentFormId" => $form_id, "Expires" => $expires, "Prices" => $price, "Currency" => $currency), $additional_flags));
-            $c = Helper::connection($parms, "createSession", "PaymentForm");
+            $c = Helper::connection($parms, "createSession", $this->group);
             if($c == true){
                 if(Helper::check_rm($c)){
                     return Cryptolens::outputHelper($c);

--- a/classes/Product.cryptolens.php
+++ b/classes/Product.cryptolens.php
@@ -68,7 +68,7 @@ namespace Cryptolens_PHP_Client {
                 };
             }
             $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, $additional_flags);
-            $c = Helper::connection($parms, "getKeys", "Product");
+            $c = Helper::connection($parms, "getKeys", $this->group);
 
             if($c == true){
                 if(Helper::check_rm($c)){
@@ -81,7 +81,7 @@ namespace Cryptolens_PHP_Client {
 
         public function get_products(){
             $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id());
-            $c = Helper::connection($parms, "getProducts", "Product");
+            $c = Helper::connection($parms, "getProducts", $this->group);
             if($c == true){
                 if(Helper::check_rm($c)){
                     return Cryptolens::outputHelper($c);

--- a/classes/Product.cryptolens.php
+++ b/classes/Product.cryptolens.php
@@ -1,0 +1,97 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class Product {
+
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+        private array $OrderByDefinitions = [
+            "cd" => "Created descending",
+            "ca" => "Created ascending",
+            "ia" => "ID ascending",
+            "id" => "ID descending",
+            "ka" => "Key ascending",
+            "kd" => "Key descending",
+            "da" => "Decives ascending",
+            "dd" => "Devices descending",
+            "ea" => "Expires ascending",
+            "ed" => "Expire descending",
+            "pa" => "Period ascending",
+            "pd" => "Period descending",
+            "f1a" => "F1 ascending",
+            "f1d" => "F1 descending",
+            "f2a" => "F2 ascending",
+            "f2d" => "F2 descending", 
+            "f3a" => "F3 ascending",
+            "f3d" => "F3 descending", 
+            "f4a" => "F4 ascending",
+            "f4d" => "F4 descending", 
+            "f5a" => "F5 ascending",
+            "f5d" => "F5 descending", 
+            "f6a" => "F6 ascending",
+            "f6d" => "F6 descending", 
+            "f7a" => "F7 ascending",
+            "f7d" => "F7 descending", 
+            "f8a" => "F8 ascending",
+            "f8d" => "F8 descending", 
+            "f9a" => "F9 ascending",
+            "f9d" => "F9 descending",
+        ];
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = Cryptolens::CRYPTOLENS_PRODUCT;
+        }
+
+        /**
+         * get_keys() Allows you to retrieve all keys
+         * 
+         * @param int $page A page only returns 99 keys. If you want to see the remaining ones, increment by 1
+         * @param $additional_flags You can set the additional `OrderBy` and `SearchQuery` flags.
+         * 
+         * `OrderBy`: For shorter usage, we defined filters for you
+         * * Take a look at the $OrderByDefinitions variable to see, which filter are available
+         * 
+         * `SearchQuery`: For more information, see <https://help.cryptolens.io/web-interface/linq-search-product>
+         */
+        public function get_keys($page = 1, $additional_flags = null){
+            if(isset($additional_flags)){
+                if(in_array("orderBy", array_flip($additional_flags))){
+                    foreach($this->OrderByDefinitions as $d => $f){
+                        switch($d){
+                            case $d == $additional_flags["orderBy"]:
+                                $additional_flags["orderBy"] = $f;
+                        }
+                    }
+                    $additional_flags = array_merge(["page" => $page], $additional_flags);
+                };
+            }
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, $additional_flags);
+            $c = Helper::connection($parms, "getKeys", "Product");
+
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            }
+        }
+
+        public function get_products(){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id());
+            $c = Helper::connection($parms, "getProducts", "Product");
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            }
+        }
+    }
+}
+
+
+?>

--- a/classes/Reseller.cryptolens.php
+++ b/classes/Reseller.cryptolens.php
@@ -1,0 +1,165 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class Reseller {
+
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = Cryptolens::CRYPTOLENS_RESELLER;
+        }
+
+        /**
+         * 
+         * `add_reseller()` - Adds a reseller
+         * 
+         * This function seems to be buggy as it always creates a new reseller and returns a value instead of an error if nothing is specified.
+         * You should not use this function at the time as the whole Reseller module is being updated
+         * 
+         * @param string $name Name of the Reseller
+         * @param string $email The email of the Reseller
+         * @param array|null $additional_flags Allows you to set "Url", "Phone", "Description" or "Metadata" (JSON dictionary)
+         * @return array|false Either returns an array containing a "Result" key, if it's 0 the operation succeded.
+         * 
+         * @link https://app.cryptolens.io/docs/api/v3/AddReseller
+         */
+
+        public function add_reseller(string $name, string $email, array $additional_flags = null){
+            if($additional_flags == null){$additional_flags = array();};
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array_merge(array("Name" => $name, "Email" => $email), $additional_flags));
+            $c = Helper::connection($parms, "addReseller", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `edit_reseller()` - Edits a reseller on the passed properties.
+         * 
+         * Only properties specified will be changed within this request
+         * The additional_flags array can may only contain the keys "Name", "Url, "Email", "Phone", "Description", "Metadata"
+         *
+         * @param array $additional_flags Possible keys are "Name", "Url, "Email", "Phone", "Description" or "Metadata"
+         * @return array|false On success the function returns an array containing the "Result" key, if it's a 0 the reseller has been edited successfully.
+         * @link https://api.cryptolens.io/api/reseller/EditReseller
+         */
+        public function edit_reseller(int $resellerId, array $additional_flags){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array_merge(array("ResellerId" => $resellerId), $additional_flags));
+            $c = Helper::connection($parms, "editReseller", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `remove_reseller()` - Removes the given Reseller
+         *
+         * @param integer $resellerId The ID of the Reseller to be removed
+         * @return array|false Returns an array key "Result" value 0 on success, if an error occurs, the message can be obtained from the "Message" key
+         * @link https://api.cryptolens.io/api/reseller/RemoveReseller
+         */
+        public function remove_reseller(int $resellerId){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("ResellerId" => $resellerId));
+            $c = Helper::connection($parms, "removeReseller", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `get_resellers()` - Search or return all Resellers
+         *
+         * @param array $search If either "Name", "Phone", "Email" or "Description" contains the search string, the result will be returned.
+         * @param integer|null $limit Specifiy the number of resellers to be returned.
+         * @return array|false Contains the Resellers if found or false. 
+         * @link https://api.cryptolens.io/api/reseller/GetResellers
+         */
+        public function get_resellers(string $search = null, int $limit = null){
+            $additional_flags = array();
+            if(isset($search)){
+                $additional_flags["Search"] = $search;
+            }
+            if(isset($limit)){
+                $additional_flags["Limit"] = $limit;
+            }
+
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, $additional_flags);
+            $c = Helper::connection($parms, "getResellers", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `get_reseller_by_id()` - Return a Reseller by his ID
+         *
+         * @param integer $resellerId The ID of the reseller to be returned
+         * @return array|false Contains either the Reseller object or false
+         * @link https://api.cryptolens.io/api/reseller/GetResellers
+         */
+        public function get_reseller_by_id(int $resellerId){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("ResellerId" => $resellerId));
+            $c = Helper::connection($parms, "getResellers", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `get_reseller_customers` - Returns all customers from a given Reseller
+         *
+         * @param integer $resellerId The ID of the reseller to return all customers
+         * @return array|false Contains either the Customer objects or false
+         * @link https://api.cryptolens.io/api/reseller/GetResellerCustomers
+         */
+        public function get_reseller_customers(int $resellerId){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("ResellerId" => $resellerId));
+            $c = Helper::connection($parms, "getResellerCustomers", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}
+
+
+?>

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -132,6 +132,12 @@ namespace Cryptolens_PHP_Client {
                     "Result",
                     "Message"
                 ]
+            ],
+            "Subscription" => [
+                "recordUsage" => [
+                    "Result",
+                    "Message"
+                ]
             ]
 
         ];

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -91,7 +91,23 @@ namespace Cryptolens_PHP_Client {
                     "Result",
                     "Message"
                 ]
-            ]
+            ],
+            "Message" => [
+                "createMessage" => [
+                    "MessageId",
+                    "Result",
+                    "Message"
+                ],
+                "removeMessage" => [
+                    "Result",
+                    "Message"
+                ],
+                "getMessages" => [
+                    "Messages",
+                    "Result",
+                    "Message"
+                ]
+            ],
 
         ];
 

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -138,6 +138,30 @@ namespace Cryptolens_PHP_Client {
                     "Result",
                     "Message"
                 ]
+            ],
+            "Customer" => [
+                "addCustomer" => [
+                    "CustomerId",
+                    "PortalLink",
+                    "Secret",
+                    "Result",
+                    "Message"
+                ],
+                "editCustomer" => [
+                    "CustomerId",
+                    "Result",
+                    "Message"
+                ],
+                "removeCustomer" => [
+                    "Result",
+                    "Message"
+                ],
+                "getCustomerLicenses" => [
+                    "LicenseKeys",
+                    "Metadata",
+                    "Result",
+                    "Message"
+                ]
             ]
 
         ];

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -1,0 +1,38 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class Results extends Endpoints {
+        public static array $results = [
+            "Key" => [
+                "activate" => [
+                    "LicenseKey",
+                    "Signature",
+                    "Result",
+                    "Message"
+                ],
+                "deactivate" => [
+                    "Result",
+                    "Message"
+                ],
+                "createKey" => [
+                    "Key",
+                    "CustomerId",
+                    "Result",
+                    "Message"
+                ],
+                "createTrialKey" => [
+                    "Key",
+                    "Result",
+                    "Message"
+                ]
+            ]
+        ];
+
+        public static function get_results(){
+            return self::$results;
+        }
+    }
+}
+
+
+
+?>

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -23,6 +23,31 @@ namespace Cryptolens_PHP_Client {
                     "Key",
                     "Result",
                     "Message"
+                ],
+                "createKeyFromTemplate" => [
+                    "Result",
+                    "Key",
+                    "RawResponse",
+                    "Message"
+                ],
+                "getKey" => [
+                    "LicenseKey",
+                    "Signature",
+                    "Metadata",
+                    "Result",
+                    "Message"
+                ],
+                "addFeature" => [
+                    "Result",
+                    "Message"
+                ],
+                "blockKey" => [
+                    "Result",
+                    "Message"
+                ],
+                "extendLicense" => [
+                    "Result",
+                    "Message"
                 ]
             ]
         ];

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -64,10 +64,10 @@ namespace Cryptolens_PHP_Client {
             ],
             "Auth" => [
                 "keyLock" => [
-                    "keyid",
-                    "token",
-                    "result",
-                    "message"
+                    "Keyid",
+                    "Token",
+                    "Result",
+                    "Message"
                 ]
                 ],
             "Product" => [
@@ -84,7 +84,15 @@ namespace Cryptolens_PHP_Client {
                     "Result",
                     "Message"
                 ]
+            ],
+            "PaymentForm" => [
+                "createSession" => [
+                    "SessionId",
+                    "Result",
+                    "Message"
+                ]
             ]
+
         ];
 
         public static function get_results(){

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -60,8 +60,30 @@ namespace Cryptolens_PHP_Client {
                 "machineLockLimit" => [
                     "Result",
                     "Message"
+                ],
+            ],
+            "Auth" => [
+                "keyLock" => [
+                    "keyid",
+                    "token",
+                    "result",
+                    "message"
                 ]
-
+                ],
+            "Product" => [
+                "getKeys" => [
+                    "LicenseKeys",
+                    "Returned",
+                    "Total",
+                    "PageCount",
+                    "Result",
+                    "Message"
+                ],
+                "getProducts" => [
+                    "Products",
+                    "Result",
+                    "Message"
+                ]
             ]
         ];
 

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -48,7 +48,20 @@ namespace Cryptolens_PHP_Client {
                 "extendLicense" => [
                     "Result",
                     "Message"
+                ],
+                "removeFeature" => [
+                    "Result",
+                    "Message"
+                ],
+                "unblockKey" => [
+                    "Result",
+                    "Message"
+                ],
+                "machineLockLimit" => [
+                    "Result",
+                    "Message"
                 ]
+
             ]
         ];
 

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -108,6 +108,31 @@ namespace Cryptolens_PHP_Client {
                     "Message"
                 ]
             ],
+            "Reseller" => [
+                "addReseller" => [
+                    "ResellerId",
+                    "Result",
+                    "Message"
+                ],
+                "editReseller" => [
+                    "Result",
+                    "Message"
+                ],
+                "removeReseller" => [
+                    "Result",
+                    "Message"
+                ],
+                "getResellers" => [
+                    "Resellers",
+                    "Result",
+                    "Message"
+                ],
+                "getResellerCustomers" => [
+                    "Customers",
+                    "Result",
+                    "Message"
+                ]
+            ]
 
         ];
 

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -161,7 +161,13 @@ namespace Cryptolens_PHP_Client {
                     "Metadata",
                     "Result",
                     "Message"
-                ]
+                ],
+                "getCustomerLicensesBySecret" => [
+                    "LicenseKeys",
+                    "Metadata",
+                    "Result",
+                    "Message"
+                    ]
                 ],
                 "Data" => [
                     "addDataObject" => [
@@ -190,6 +196,37 @@ namespace Cryptolens_PHP_Client {
                         "Message"
                     ],
                     "uploadValues" => [
+                        "Result",
+                        "Message"
+                    ]
+                ],
+                "User" =>  [
+                    "login" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "register" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "associate" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "dissociate" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "getUsers" => [
+                        "Users",
+                        "Result",
+                        "Message"
+                    ],
+                    "changePassword" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "removeUser" => [
                         "Result",
                         "Message"
                     ]

--- a/classes/Results.endpoints.cryptolens.php
+++ b/classes/Results.endpoints.cryptolens.php
@@ -162,7 +162,38 @@ namespace Cryptolens_PHP_Client {
                     "Result",
                     "Message"
                 ]
-            ]
+                ],
+                "Data" => [
+                    "addDataObject" => [
+                        "Result",
+                        "Message",
+                        "Id"
+                    ],
+                    "incrementIntValue" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "decramentIntValue" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "setStringValue" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "setIntValue" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "removeDataObject" => [
+                        "Result",
+                        "Message"
+                    ],
+                    "uploadValues" => [
+                        "Result",
+                        "Message"
+                    ]
+                ]
 
         ];
 

--- a/classes/Subscription.cryptolens.php
+++ b/classes/Subscription.cryptolens.php
@@ -1,0 +1,44 @@
+<?php
+namespace Cryptolens_PHP_Client {
+    class Subscription {
+
+        private Cryptolens $cryptolens;
+
+        private string $group;
+
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = Cryptolens::CRYPTOLENS_SUBSCRIPTION;
+        }
+
+
+        /**
+         * `record_usage()` - Allows you to record usage for Stripe's metered billing.
+         * 
+         * This API request is parsed to Stripe with the action "increment" - https://app.cryptolens.io/docs/api/v3/RecordUsage
+         *
+         * @param string $key The Key to record usage on
+         * @param integer $amout The amount to increment the usage counter (this is actually optional)
+         * @return array|false On success the "Result" key has the value 0 otherwise the "Error" key is set
+         * 
+         * @link https://api.cryptolens.io/api/subscription/RecordUsage
+         */
+        public function record_usage(string $key, int $amount = 0){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, array("Key" => $key, "Amount" => $amount));
+            $c = Helper::connection($parms, "recordUsage", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}
+
+
+?>

--- a/classes/User.cryptolens.php
+++ b/classes/User.cryptolens.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Cryptolens_PHP_Client {
+    class User {
+
+        public Cryptolens $cryptolens;
+
+        public string $group;
+
+        public function __construct(Cryptolens $cryptolens){
+            $this->cryptolens = $cryptolens;
+            $this->group = CRYPTOLENS::CRYPTOLENS_USER;
+        }
+
+        /**
+         * `login()` - Login the user and get all licenses that belong to it.
+         * @param string $username The username
+         * @param string $password The password
+         * @link https://app.cryptolens.io/docs/api/v3/Login
+         * @return array|bool|string
+         */
+        public function login(string $username, string $password){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+                "Password" => $password
+            ]);
+
+            $c = Helper::connection($parms, "login", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `register()` - Register a new user
+         * @param string $username The username
+         * @param string $password The password
+         * @param string $customerId The customer object ID to associate the user to
+         * @param string $email The email
+         * @link https://app.cryptolens.io/docs/api/v3/Register
+         * @return array|bool|string
+         */
+        public function register(string $username, string $password, string $customerId = null, string $email = null){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+                "Password" => $password,
+                "CustomerId" => $customerId,
+                "Email" => $email
+            ]);
+
+            $c = Helper::connection($parms, "register", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `associate()` - Associates a user with a customer object.
+         * @param string $username Username to associate customer object with
+         * @param string $customerId The customer object ID to associate to (this value is optional, but what's the point behind calling this function w/ a customer ID?)
+         * @link https://app.cryptolens.io/docs/api/v3/Associate
+         * @return array|bool
+         */
+        public function associate(string $username, string $customerId = null){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+                "CustomerId" => $customerId,
+            ]);
+
+            $c = Helper::connection($parms, "associate", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `dissociate()` - Dissociates a user from a customer object
+         * @param string $username The username to dissociate the customer object with
+         * @link https://app.cryptolens.io/docs/api/v3/Dissociate
+         * @return array|bool
+         */
+        public function dissociate(string $username){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username
+            ]);
+
+            $c = Helper::connection($parms, "dissociate", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `getUsers` - Returns a list of all users
+         * @param string $customerId optional customer object ID to get all associates users from
+         * @link https://app.cryptolens.io/docs/api/v3/GetUsers
+         * @return array|bool
+         */
+        public function getUsers(string $customerId = null){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "customerId" => $customerId,
+            ]);
+
+            $c = Helper::connection($parms, "getUsers", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `changePassword()` - Change the Password of a specific user
+         * @param string $username The username
+         * @param string $newPassword The new password
+         * @param string $oldPassword optional old password if available
+         * @param string $passwordResetToken optional password reset token if available (irrelevant, as the API client requires the token to be set)
+         * @param bool $adminMode optional boolean to specify if user has admin mode enabled
+         * @link https://app.cryptolens.io/docs/api/v3/ChangePassword
+         * @return array|bool
+         */
+        public function changePassword(string $username, string $newPassword, string $oldPassword = null, string $passwordResetToken = null, bool $adminMode = false){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+                "OldPassword" => $oldPassword,
+                "NewPassword" => $newPassword,
+                "PasswordResetToken" => $passwordResetToken,
+                "AdminMode" => $adminMode
+            ]);
+
+            $c = Helper::connection($parms, "changePassword", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `resetPasswordToken()` - Get the user's password reset token to perform the `changePassword` method on (irrelevant, as the API client requires the token to be set)
+         * @param string $username The username to get the reset token
+         * @link https://app.cryptolens.io/docs/api/v3/ResetPasswordToken
+         * @return array|bool
+         */
+        public function resetPasswordToken(string $username){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+            ]);
+
+            $c = Helper::connection($parms, "resetPasswordToken", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * `removeUser()` - Removes a specified user
+         * @param string $username The username
+         * @link https://app.cryptolens.io/docs/api/v3/RemoveUser
+         * @return array|bool
+         */
+        public function removeUser(string $username){
+            $parms = Helper::build_params($this->cryptolens->get_token(), $this->cryptolens->get_product_id(), null, null, [
+                "Username" => $username,
+            ]);
+
+            $c = Helper::connection($parms, "removeUser", $this->group);
+            if($c == true){
+                if(Helper::check_rm($c)){
+                    return Cryptolens::outputHelper($c);
+                } else {
+                    return Cryptolens::outputHelper($c, 1);
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "authors": [
         {
             "name": "Ente",
-            "email": "ente@openducks.org"
+            "email": "bryan@duckerz.de"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "require": {
         "php": ">=7.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
-    "version": "0.7",
+    "version": "0.8",
     "authors": [
         {
             "name": "Ente",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "authors": [
         {
             "name": "Ente",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
-    "version": "0.5",
+    "version": "0.7",
     "authors": [
         {
             "name": "Ente",

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,15 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
-    "version": "0.4.3",
+    "version": "0.5",
     "authors": [
         {
             "name": "Ente",
             "email": "bryan@duckerz.de"
+        },
+        {
+            "name": "Cryptolens AB",
+            "homepage": "https://cryptolens.io"
         }
     ],
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "ente/cryptolens-php",
+    "description": "Manage your licenses with this Cryptolens API client",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Ente",
+            "email": "ente@openducks.org"
+        }
+    ],
+    "minimum-stability": "dev",
+    "require": {
+        "php": ">=7.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "Cryptolens_PHP_Client\\": "classes/"
+        },
+        "files": [
+            "Cryptolens.php"
+        ]
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
+    "version": "0.4.1",
     "authors": [
         {
             "name": "Ente",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
-    "version": "0.8",
+    "version": "0.9",
     "authors": [
         {
             "name": "Ente",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
-    "version": "1.0",
+    "version": "1.1",
     "authors": [
         {
             "name": "Ente",

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "Manage your licenses with this Cryptolens API client",
     "type": "library",
     "license": "MIT",
-    "version": "0.9",
+    "version": "1.0",
     "authors": [
         {
             "name": "Ente",
-            "email": "bryan@duckerz.de"
+            "email": "github@openducks.org"
         },
         {
             "name": "Cryptolens AB",

--- a/examples/create-key-for-customer.php
+++ b/examples/create-key-for-customer.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This example shows how to create a key for a new customer and then later activate the key on a machine
+ * To create a example customer and a automated link to the key the customer bought, simply boot up a PHP webserver (e.g. `php -S 0.0.0.0`) and access via browser with "?exampleCustomer"
+ * 
+ * You atleast require to use the base cryptolens, customer and key class.
+ */
+
+require "../loader.php";
+
+use Cryptolens_PHP_Client\Cryptolens;
+use Cryptolens_PHP_Client\Customer;
+use Cryptolens_PHP_Client\Key;
+
+$c = new Cryptolens("YOUR_TOKEN", 12345, Cryptolens::CRYPTOLENS_OUTPUT_PHP);
+$cc = new Customer($c);
+$k = new Key($c);
+
+/**  
+* assuming you're recieving the request to add a new customer
+* the $data array should contain the following keys: name, email, company_name, additional_flags
+* For the additional_flags, please see the function documentation for Cryptolens_PHP_Client\Customer::add_customer() */
+function add_customer($data, $cc){
+    $customerIsAdded = $cc->add_customer($data["name"], $data["email"], $data["company_name"], $data["additional_flags"]);
+
+    if($customerIsAdded != false){
+        return $customerIsAdded["customerId"];
+    } else {
+        die($customerIsAdded);
+    }
+}
+
+function link_key($customer_id, $k){
+    $key = $k->create_key(array("CustomerId" => $customer_id, "MachineId" => $k->getMachineId()));
+    if($key != false){
+        return $key;
+    } else {
+        die($key);
+    }
+}
+
+if($_GET["action"] == "addCustomer"){
+    if(isset($_GET["name"], $_GET["email"], $_GET["company_name"])){
+        $data = [
+            "name" => $_GET["name"],
+            "email" => $_GET["email"],
+            "company_name" => $_GET["company_name"],
+            "additional_flags" => unserialize($_GET["additional_flags"])
+        ];
+        $customer = add_customer($data, $cc);
+        if($customer != false){
+            $key = link_key($customer, $k);
+            if($key != false){
+                echo "Key " . $key["key"] . " has been linked to customer ID " . $customer . " and machine ID" . $k->getMachineId();
+            } else {
+                echo "An error occured\n";
+                print_r($key);
+            }
+        } else {
+            echo "An error occured\n";
+            print_r($customer);
+        }
+    }
+}
+
+if(isset($_GET["exampleCustomer"])){
+    $data = [
+        "action" => "addCustomer",
+        "name" => "John Doe",
+        "email" => "john.doe@acme.inc",
+        "company_name" => "Acme Inc.",
+        "additional_flags" => serialize(array("AllowActivationManagement" => true))
+    ];
+    $data = http_build_query($data);
+    header("Location: ?{$data}");
+}

--- a/examples/create-key-for-customer.php
+++ b/examples/create-key-for-customer.php
@@ -7,7 +7,7 @@
  * You atleast require to use the base cryptolens, customer and key class.
  */
 
-require "../loader.php";
+require_once "../loader.php";
 
 use Cryptolens_PHP_Client\Cryptolens;
 use Cryptolens_PHP_Client\Customer;

--- a/examples/enable-and-check-feature.php
+++ b/examples/enable-and-check-feature.php
@@ -9,7 +9,7 @@
  */
 
 
-require "../loader.php";
+require_once "../loader.php";
 
 use Cryptolens_PHP_Client\Cryptolens;
 use Cryptolens_PHP_Client\Key;

--- a/examples/enable-and-check-feature.php
+++ b/examples/enable-and-check-feature.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This example shows how to enable a feature for a certain key and to check if it actually has been enabled.
+ * To create a sample key, you can simply access this example file within your browser adding parameter "?keyCreate"
+ * 
+ * 
+ * In this scenario we will try to figure out if our customer has a certain feature (in this example feature 1) enabled, which we will refer on as "pro" 
+ */
+
+
+require "../loader.php";
+
+use Cryptolens_PHP_Client\Cryptolens;
+use Cryptolens_PHP_Client\Key;
+
+$c = new Cryptolens("YOUR_TOKEN", 12345, Cryptolens::CRYPTOLENS_OUTPUT_PHP);
+$k = new Key($c);
+
+function check_pro_enabled($key, $k){
+    $key = $k->get_key($key);
+
+    if($key != false){
+        $key = json_decode($key["licenseKey"], true);
+        if($key["F1"] == true){
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        return false;
+    }
+}
+
+if($_GET["action"] == "checkPro"){
+    if(isset($_GET["key"])){
+        if(check_pro_enabled($_GET["key"], $k)){
+            echo "Feature 1 enabled for key " . $_GET["key"];
+        } else {
+            echo "Failed to check for enabled Feature 1 on key " . $_GET["key"];
+        }
+    }
+}
+
+
+if($_GET["action"] == "exampleCheckPro"){
+    if(check_pro_enabled("EXAMPLE_KEY", $k)){
+        echo "Feature 1 enabled for key " . "EXAMPLE_KEY";
+    } else {
+        echo "Failed to check for enabled Feature 1 on key " . "EXAMPLE_KEY";
+    }
+}

--- a/loader.php
+++ b/loader.php
@@ -1,0 +1,8 @@
+<?php
+require_once "Cryptolens.php";
+use Cryptolens_PHP_Client\Cryptolens;
+Cryptolens::loader();
+
+
+
+?>


### PR DESCRIPTION
## v1.1

* added support to User authentication endpoints `login`, `register`, `associate`, `dissociate`, `getUsers`, `changePassword`, `resetPasswordToken`, `removeUser` <!-- I simply forgot this endpoint group exists aswell or it has been added newly. -->
* added support to Customer endpoint `get_customer_licenses_by_secret`

<!--  additionally removed some unused code and fixed 2 things-->